### PR TITLE
docs: add markdown syntax reference and link from help modal

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,97 @@
+# Markdown syntax
+
+Earnesty uses a focused subset of Markdown. Below is everything you can use.
+
+---
+
+## Headings
+
+```
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+```
+
+---
+
+## Emphasis
+
+```
+**bold**
+*italic*
+~~strikethrough~~
+```
+
+---
+
+## Lists
+
+Unordered — use `-` or `*`:
+
+```
+- First item
+- Second item
+  - Nested item
+```
+
+Ordered:
+
+```
+1. First item
+2. Second item
+```
+
+---
+
+## Blockquote
+
+```
+> This is a blockquote.
+```
+
+---
+
+## Code
+
+Inline: wrap in backticks.
+
+```
+Use `console.log()` to debug.
+```
+
+Fenced code block (optionally with a language for syntax highlighting):
+
+````
+```javascript
+const greeting = 'Hello, world!'
+```
+````
+
+---
+
+## Links
+
+```
+[Link text](https://example.com)
+```
+
+URLs typed or pasted directly are auto-linked.
+
+---
+
+## Images
+
+```
+![Alt text](https://example.com/image.png)
+```
+
+---
+
+## Horizontal rule
+
+```
+---
+```

--- a/frontend/src/components/HelpModal.vue
+++ b/frontend/src/components/HelpModal.vue
@@ -26,6 +26,15 @@ const shortcuts = [
       Earnesty is a distraction-free writing environment. Click anywhere on the page and start
       typing. Your words are the only thing that matters.
     </p>
+    <p class="intro">
+      Markdown is supported for formatting.
+      <a
+        href="https://github.com/sjovang/earnesty/blob/main/docs/markdown.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="docs-link"
+      >See which syntax is available →</a>
+    </p>
 
     <h3 class="section-title">
       Keyboard shortcuts
@@ -50,6 +59,16 @@ const shortcuts = [
   font-size: 0.9rem;
   line-height: 1.6;
   margin-bottom: 1.25rem;
+}
+
+.docs-link {
+  color: var(--ctp-blue);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.docs-link:hover {
+  text-decoration: underline;
 }
 
 .section-title {


### PR DESCRIPTION
## Summary

- Adds `docs/markdown.md` documenting all supported Markdown syntax, matching the Tiptap extensions used in the editor (StarterKit, Link, Image, CodeBlockLowlight)
- Updates the Help modal with a friendly sentence and a direct link to the GitHub docs page