### PR TITLE
fix: use popup window for Sanity OAuth

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,9 +6,18 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 
-const app = createApp(App)
+// OAuth popup callback: if this window was opened by loginWith() and Sanity
+// has redirected back here with a token, relay it to the parent and close.
+const _params = new URLSearchParams(window.location.search)
+const _hash   = new URLSearchParams(window.location.hash.slice(1))
+const _token  = _params.get('token') ?? _hash.get('token')
 
-app.use(createPinia())
-app.use(router)
-
-app.mount('#app')
+if (window.opener && _token) {
+  window.opener.postMessage({ type: 'sanity-auth-token', token: _token }, window.location.origin)
+  window.close()
+} else {
+  const app = createApp(App)
+  app.use(createPinia())
+  app.use(router)
+  app.mount('#app')
+}

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -30,16 +30,46 @@ export const useAuthStore = defineStore('auth', () => {
   const error = ref<string | null>(null)
   const isAuthenticated = computed(() => !!token.value)
 
-  /** Redirect the browser to a provider login page. */
+  /** Open a provider login popup. Posts a token message back when complete. */
   function loginWith(providerUrl: string) {
-    const origin = window.location.origin + window.location.pathname
-    // Use URL API to safely append ?origin= regardless of existing params
+    const origin = window.location.origin
     const url = new URL(providerUrl)
     url.searchParams.set('origin', origin)
     const target = url.toString()
     log(`Origin sent to Sanity: ${origin}`)
-    log(`Redirecting to provider: ${target}`)
-    window.location.href = target
+    log(`Opening OAuth popup: ${target}`)
+
+    const popup = window.open(target, 'sanity-auth', 'width=620,height=720,menubar=no,toolbar=no,scrollbars=yes')
+
+    if (!popup || popup.closed) {
+      // Popup blocked — fall back to full-page redirect (initialize() will pick up token on reload)
+      log('Popup blocked, falling back to full-page redirect')
+      window.location.href = target
+      return
+    }
+
+    popup.focus()
+
+    const messageHandler = async (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return
+      if (event.data?.type !== 'sanity-auth-token' || !event.data.token) return
+      window.removeEventListener('message', messageHandler)
+      clearInterval(pollInterval)
+      log('Token received via postMessage')
+      setToken(event.data.token as string)
+      await fetchUser()
+    }
+
+    window.addEventListener('message', messageHandler)
+
+    // Clean up listener if the user closes the popup without completing auth
+    const pollInterval = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(pollInterval)
+        window.removeEventListener('message', messageHandler)
+        log('OAuth popup closed without token')
+      }
+    }, 500)
   }
 
   /** Fetch the list of configured auth providers for this Sanity project. */


### PR DESCRIPTION
Switches from full-page redirect to popup + postMessage for auth. The redirect was losing the token before Vue could read it.