### PR TITLE
fix: restore missing .signin__loading selector in SignInModal

### DIFF
--- a/frontend/src/components/SignInModal.vue
+++ b/frontend/src/components/SignInModal.vue
@@ -221,6 +221,7 @@ onMounted(() => auth.fetchProviders())
 }
 
 
+.signin__loading {
   font-size: 0.85rem;
   color: var(--ctp-subtext0);
   margin: 0;


### PR DESCRIPTION
Fixes PostCSS parse error caused by orphaned CSS declarations.