### PR TITLE
fix: replace popup auth with clean full-page redirect

### DIFF
--- a/frontend/src/components/SignInModal.vue
+++ b/frontend/src/components/SignInModal.vue
@@ -44,44 +44,27 @@ onMounted(() => auth.fetchProviders())
         </button>
       </div>
 
-      <!-- Pending state while OAuth popup is open -->
       <div
-        v-if="auth.pendingAuth"
-        class="signin__pending"
+        v-if="auth.providers.length"
+        class="signin__providers"
       >
-        <span class="signin__pending-spinner" aria-hidden="true" />
-        <span>Waiting for sign-in to complete…</span>
         <button
-          class="signin__pending-cancel"
-          @click="auth.cancelAuth()"
+          v-for="p in auth.providers"
+          :key="p.name"
+          class="signin__provider"
+          @click="auth.loginWith(p.url)"
         >
-          Cancel
+          <span class="signin__provider-icon">{{ providerIcons[p.name] ?? '→' }}</span>
+          {{ p.title }}
         </button>
       </div>
 
-      <template v-else>
-        <div
-          v-if="auth.providers.length"
-          class="signin__providers"
-        >
-          <button
-            v-for="p in auth.providers"
-            :key="p.name"
-            class="signin__provider"
-            @click="auth.loginWith(p.url)"
-          >
-            <span class="signin__provider-icon">{{ providerIcons[p.name] ?? '→' }}</span>
-            {{ p.title }}
-          </button>
-        </div>
-
-        <p
-          v-else-if="!auth.error"
-          class="signin__loading"
-        >
-          Loading…
-        </p>
-      </template>
+      <p
+        v-else-if="!auth.error"
+        class="signin__loading"
+      >
+        Loading…
+      </p>
 
       <div
         v-if="isDev"
@@ -176,50 +159,6 @@ onMounted(() => auth.fetchProviders())
   font-size: 0.8rem;
   color: var(--ctp-subtext1);
 }
-
-.signin__pending {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.75rem 1rem;
-  background: color-mix(in srgb, var(--ctp-blue) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ctp-blue) 25%, transparent);
-  border-radius: 7px;
-  font-size: 0.85rem;
-  color: var(--ctp-subtext1);
-}
-
-.signin__pending-spinner {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid color-mix(in srgb, var(--ctp-blue) 30%, transparent);
-  border-top-color: var(--ctp-blue);
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-  flex-shrink: 0;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.signin__pending-cancel {
-  margin-left: auto;
-  background: none;
-  border: none;
-  color: var(--ctp-subtext0);
-  font-size: 0.8rem;
-  cursor: pointer;
-  padding: 0;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.signin__pending-cancel:hover {
-  color: var(--ctp-text);
-}
-
 
 .signin__loading {
   font-size: 0.85rem;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -17,7 +17,6 @@ export interface SanityAuthProvider {
 
 const TOKEN_KEY = 'earnesty-auth-token'
 const PROJECT_ID = import.meta.env.VITE_SANITY_PROJECT_ID as string
-const BROADCAST_CHANNEL = 'earnesty-auth'
 const DEV = import.meta.env.DEV
 
 function log(...args: unknown[]) {
@@ -29,76 +28,15 @@ export const useAuthStore = defineStore('auth', () => {
   const user = ref<SanityUser | null>(null)
   const providers = ref<SanityAuthProvider[]>([])
   const error = ref<string | null>(null)
-  const pendingAuth = ref(false)
   const isAuthenticated = computed(() => !!token.value)
 
-  let _popup: Window | null = null
-  let _popupPoll: ReturnType<typeof setInterval> | null = null
-  let _channel: BroadcastChannel | null = null
-
-  function _openChannel() {
-    if (_channel) return
-    _channel = new BroadcastChannel(BROADCAST_CHANNEL)
-    _channel.onmessage = async (event: MessageEvent) => {
-      const { type, token: t, message } = event.data as { type: string; token?: string; message?: string }
-      if (type === 'auth-success' && t) {
-        log('Token received via BroadcastChannel')
-        _cleanupPopup()
-        setToken(t)
-        await fetchUser()
-      } else if (type === 'auth-error') {
-        log('Auth error via BroadcastChannel:', message)
-        _cleanupPopup()
-        error.value = message ?? 'Sign-in failed. Please try again.'
-      }
-    }
-  }
-
-  function _cleanupPopup() {
-    pendingAuth.value = false
-    if (_popupPoll) { clearInterval(_popupPoll); _popupPoll = null }
-    if (_popup && !_popup.closed) _popup.close()
-    _popup = null
-  }
-
-  /**
-   * Open a provider login popup. Sanity will redirect back to /callback
-   * which broadcasts the token via BroadcastChannel.
-   */
+  /** Redirect the browser to a provider login page. Sanity will redirect back to /callback. */
   function loginWith(providerUrl: string) {
-    error.value = null
-    const callbackOrigin = window.location.origin + '/callback'
+    const callbackUrl = window.location.origin + '/callback'
     const url = new URL(providerUrl)
-    url.searchParams.set('origin', callbackOrigin)
-    const target = url.toString()
-    log(`Opening OAuth popup (origin: ${callbackOrigin})`)
-
-    _openChannel()
-
-    const popup = window.open(target, 'sanity-auth', 'width=480,height=640,menubar=no,toolbar=no,scrollbars=yes')
-
-    if (!popup || popup.closed) {
-      log('Popup blocked — falling back to full-page redirect')
-      window.location.href = target
-      return
-    }
-
-    _popup = popup
-    popup.focus()
-    pendingAuth.value = true
-
-    // Detect if the user closes the popup without completing auth
-    _popupPoll = setInterval(() => {
-      if (popup.closed) {
-        log('OAuth popup closed without completing auth')
-        _cleanupPopup()
-      }
-    }, 500)
-  }
-
-  function cancelAuth() {
-    log('Auth cancelled by user')
-    _cleanupPopup()
+    url.searchParams.set('origin', callbackUrl)
+    log(`Redirecting to provider (callback: ${callbackUrl})`)
+    window.location.href = url.toString()
   }
 
   /** Fetch the list of configured auth providers for this Sanity project. */
@@ -133,7 +71,6 @@ export const useAuthStore = defineStore('auth', () => {
 
   function logout() {
     log('Logging out')
-    _cleanupPopup()
     token.value = null
     user.value = null
     error.value = null
@@ -176,8 +113,22 @@ export const useAuthStore = defineStore('auth', () => {
 
   async function initialize() {
     log('Initializing — URL:', window.location.href)
-    // Open the broadcast channel so we're ready to receive tokens from the callback popup.
-    _openChannel()
+
+    // Check for an auth error relayed from /callback (e.g. origin not allowed by Sanity)
+    const params = new URLSearchParams(window.location.search)
+    const authError = params.get('auth_error')
+    if (authError) {
+      error.value = decodeURIComponent(authError)
+      const clean = new URL(window.location.href)
+      clean.searchParams.delete('auth_error')
+      window.history.replaceState({}, '', clean.toString())
+    }
+
+    // Token is always read from localStorage (written by CallbackView after redirect)
+    const stored = localStorage.getItem(TOKEN_KEY)
+    if (stored && stored !== token.value) {
+      setToken(stored)
+    }
 
     if (token.value) {
       log('Resuming session from localStorage')
@@ -187,9 +138,7 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  return {
-    token, user, providers, error, pendingAuth, isAuthenticated,
-    loginWith, cancelAuth, fetchProviders, logout, clearError, initialize,
-  }
+  return { token, user, providers, error, isAuthenticated, loginWith, fetchProviders, logout, clearError, initialize }
 })
+
 

--- a/frontend/src/views/CallbackView.vue
+++ b/frontend/src/views/CallbackView.vue
@@ -2,8 +2,8 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 
+const TOKEN_KEY = 'earnesty-auth-token'
 const router = useRouter()
-const CHANNEL = 'earnesty-auth'
 const DEV = import.meta.env.DEV
 
 function log(...args: unknown[]) {
@@ -16,28 +16,17 @@ onMounted(() => {
   const errorCode = params.get('error')
   const errorDesc = params.get('error_description')
 
-  const channel = new BroadcastChannel(CHANNEL)
-
   if (token) {
-    log('Token received, broadcasting auth-success')
-    channel.postMessage({ type: 'auth-success', token })
-  } else if (errorCode) {
-    const message = errorDesc ?? errorCode
-    log('OAuth error received:', message)
-    channel.postMessage({ type: 'auth-error', message })
-  } else {
-    log('No token or error in callback URL')
-    channel.postMessage({ type: 'auth-error', message: 'Sign-in did not complete. Please try again.' })
-  }
-
-  channel.close()
-
-  // If we were opened as a popup, close the window.
-  // Otherwise (redirect fallback), navigate home — the main app will read from localStorage.
-  if (window.opener) {
-    window.close()
-  } else {
+    log('Token received, saving to localStorage')
+    localStorage.setItem(TOKEN_KEY, token)
     void router.replace('/')
+  } else if (errorCode) {
+    const message = encodeURIComponent(errorDesc ?? errorCode)
+    log('OAuth error received:', decodeURIComponent(message))
+    void router.replace(`/?auth_error=${message}`)
+  } else {
+    log('No token or error in callback URL — redirecting home')
+    void router.replace('/?auth_error=Sign-in+did+not+complete.+Please+try+again.')
   }
 })
 </script>


### PR DESCRIPTION
Removes all popup/BroadcastChannel complexity. Standard OAuth redirect flow: loginWith() redirects → Sanity OAuth → /callback saves token → redirect to /.