### PR TITLE
fix: check hash fragment for token in callback

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -113,6 +113,8 @@ export const useAuthStore = defineStore('auth', () => {
 
   async function initialize() {
     log('Initializing — URL:', window.location.href)
+    log('Query string:', window.location.search)
+    log('Hash:', window.location.hash)
 
     // Check for an auth error relayed from /callback (e.g. origin not allowed by Sanity)
     const params = new URLSearchParams(window.location.search)

--- a/frontend/src/views/CallbackView.vue
+++ b/frontend/src/views/CallbackView.vue
@@ -11,10 +11,18 @@ function log(...args: unknown[]) {
 }
 
 onMounted(() => {
+  log('Full URL:', window.location.href)
+
   const params = new URLSearchParams(window.location.search)
-  const token = params.get('token')
-  const errorCode = params.get('error')
-  const errorDesc = params.get('error_description')
+  const hashParams = new URLSearchParams(window.location.hash.slice(1))
+
+  // Sanity may return the token as ?token= or #token=
+  const token = params.get('token') ?? hashParams.get('token')
+  const errorCode = params.get('error') ?? hashParams.get('error')
+  const errorDesc = params.get('error_description') ?? hashParams.get('error_description')
+
+  log('Query params:', window.location.search)
+  log('Hash params:', window.location.hash)
 
   if (token) {
     log('Token received, saving to localStorage')
@@ -25,11 +33,28 @@ onMounted(() => {
     log('OAuth error received:', decodeURIComponent(message))
     void router.replace(`/?auth_error=${message}`)
   } else {
-    log('No token or error in callback URL — redirecting home')
+    log('No token or error — check full URL above for clues')
     void router.replace('/?auth_error=Sign-in+did+not+complete.+Please+try+again.')
   }
 })
 </script>
+
+<template>
+  <div class="callback">
+    <p>Completing sign-in…</p>
+  </div>
+</template>
+
+<style scoped>
+.callback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-size: 0.9rem;
+  color: var(--ctp-subtext0);
+}
+</style>
 
 <template>
   <div class="callback">


### PR DESCRIPTION
Handle Sanity returning token as #token= fragment, and add full URL logging.