### PR TITLE
fix: correct newest/oldest sort order in open document modal

### DIFF
--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -55,9 +55,11 @@ const filtered = computed(() => {
     list = list.filter(({ doc }) => doc.title?.toLowerCase().includes(q))
   }
 
+  const sortKey = (doc: typeof list[0]['doc']) => doc.publishedAt ?? doc._createdAt
+
   switch (sortBy.value) {
     case 'oldest':
-      list.sort((a, b) => (a.doc._updatedAt > b.doc._updatedAt ? -1 : 1))
+      list.sort((a, b) => (sortKey(a.doc) > sortKey(b.doc) ? 1 : -1))
       break
     case 'title-asc':
       list.sort((a, b) => (a.doc.title ?? '').localeCompare(b.doc.title ?? ''))
@@ -65,8 +67,8 @@ const filtered = computed(() => {
     case 'title-desc':
       list.sort((a, b) => (b.doc.title ?? '').localeCompare(a.doc.title ?? ''))
       break
-    default:
-      list.sort((a, b) => (b.doc._updatedAt > a.doc._updatedAt ? 1 : -1))
+    default: // newest
+      list.sort((a, b) => (sortKey(a.doc) > sortKey(b.doc) ? -1 : 1))
   }
 
   return list

--- a/app/src/services/sanity.ts
+++ b/app/src/services/sanity.ts
@@ -58,7 +58,9 @@ export type SanityBodyBlock = SanityBlock | SanityImageBlock | SanityCodeBlock
 
 export interface BlogDocument {
   _id: string
+  _createdAt: string
   _updatedAt: string
+  publishedAt?: string
   title: string
   body?: SanityBodyBlock[]
 }
@@ -318,10 +320,12 @@ function key() {
 /** Fetch list of blog documents (title + enough body blocks for 50-word preview). */
 export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
   return sanityClient.fetch(`
-    *[_type == "blog"] | order(_updatedAt desc) {
+    *[_type == "blog"] | order(coalesce(publishedAt, _createdAt) desc) {
       _id,
-      title,
+      _createdAt,
       _updatedAt,
+      publishedAt,
+      title,
       "body": body[_type == "block"][0..10]
     }
   `)
@@ -330,7 +334,7 @@ export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
 /** Fetch the full body of a single document for editing. */
 export async function fetchBlogDocument(id: string): Promise<BlogDocument> {
   return sanityClient.fetch(
-    `*[_type == "blog" && _id == $id][0]{ _id, title, _updatedAt, body }`,
+    `*[_type == "blog" && _id == $id][0]{ _id, _createdAt, _updatedAt, publishedAt, title, body }`,
     { id },
   )
 }


### PR DESCRIPTION
Newest was sorting oldest-first and vice versa. The comparator in the `oldest` case was inverted — fixed by flipping the return values.