### PR TITLE
fix: restrict SWA location to supported regions

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -4,8 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       location:
-        description: Azure region
-        default: swedencentral
+        description: 'Azure region (must be supported by Microsoft.Web/staticSites: westus2, centralus, eastus2, westeurope, eastasia)'
+        default: westeurope
+        type: choice
+        options:
+          - westeurope
+          - westus2
+          - centralus
+          - eastus2
+          - eastasia
       sku:
         description: Static Web App SKU
         default: Standard
@@ -40,10 +47,10 @@ jobs:
         run: |
           az stack sub create \
             --name "earnesty" \
-            --location "${{ inputs.location || vars.AZURE_LOCATION || 'swedencentral' }}" \
+            --location "${{ inputs.location || vars.AZURE_LOCATION || 'westeurope' }}" \
             --template-file infra/main.bicep \
             --parameters \
-              location="${{ inputs.location || vars.AZURE_LOCATION || 'swedencentral' }}" \
+              location="${{ inputs.location || vars.AZURE_LOCATION || 'westeurope' }}" \
               staticWebAppSku="${{ inputs.sku || vars.STATIC_WEB_APP_SKU || 'Standard' }}" \
               entraClientId="${{ secrets.ENTRA_CLIENT_ID }}" \
               entraClientSecret="${{ secrets.ENTRA_CLIENT_SECRET }}" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,10 +50,10 @@ jobs:
         run: |
           az stack sub create \
             --name "earnesty" \
-            --location "${{ vars.AZURE_LOCATION || 'swedencentral' }}" \
+            --location "${{ vars.AZURE_LOCATION || 'westeurope' }}" \
             --template-file infra/main.bicep \
             --parameters \
-              location="${{ vars.AZURE_LOCATION || 'swedencentral' }}" \
+              location="${{ vars.AZURE_LOCATION || 'westeurope' }}" \
               staticWebAppSku="${{ vars.STATIC_WEB_APP_SKU || 'Standard' }}" \
               entraClientId="${{ secrets.ENTRA_CLIENT_ID }}" \
               entraClientSecret="${{ secrets.ENTRA_CLIENT_SECRET }}" \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -2,8 +2,9 @@ targetScope = 'subscription'
 
 // ── Parameters ────────────────────────────────────────────────────────────────
 
-@description('Azure region for the resource group and all resources.')
-param location string = 'swedencentral'
+@description('Azure region for the resource group and all resources. Must be a region supported by Microsoft.Web/staticSites.')
+@allowed(['westus2', 'centralus', 'eastus2', 'westeurope', 'eastasia'])
+param location string = 'westeurope'
 
 @description('Base name used for resource naming across the stack.')
 param appName string = 'earnesty'


### PR DESCRIPTION
## Problem

`Microsoft.Web/staticSites` is only available in 5 regions: `westus2`, `centralus`, `eastus2`, `westeurope`, `eastasia`. The previous default of `swedencentral` caused deployment failures.

## Changes

- **`infra/main.bicep`**: Added `@allowed` constraint on `location` parameter listing the 5 valid SWA regions. Updated default from `swedencentral` to `westeurope`.
- **`.github/workflows/deploy-infra.yml`**: Changed the manual trigger `location` input to a `choice` type with only valid options. Updated default and fallback to `westeurope`.
- **`.github/workflows/release-please.yml`**: Updated fallback default from `swedencentral` to `westeurope`.