### PR TITLE
fix: point SWA deploy to app/dist to avoid node_modules in static files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
-          app_location: app
+          app_location: app/dist
           api_location: app/api
-          output_location: dist
+          output_location: ""
           skip_app_build: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -102,7 +102,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
-          app_location: app
+          app_location: app/dist
           api_location: app/api
-          output_location: dist
+          output_location: ""
           skip_app_build: true


### PR DESCRIPTION
## Problem

```
The content server has rejected the request with: BadRequest
Reason: The number of static files was too large.
```

The SWA deployer was scanning `app/` (the `app_location`) and picking up `node_modules` as candidate static files.

## Fix

Set `app_location: app/dist` (the pre-built output) and `output_location: ""` so the deployer only sees the compiled assets — not `node_modules`.