### PR TITLE
fix: prevent theme FOUC and add post_login_redirect_uri for auth

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,17 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Apply saved theme before first paint to prevent flash of wrong theme -->
+    <script>
+      ;(function () {
+        try {
+          var s = JSON.parse(localStorage.getItem('ernesty:settings') || '{}')
+          document.documentElement.setAttribute('data-theme', s.theme || 'dark')
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark')
+        }
+      })()
+    </script>
     <title>Earnesty — Your space for focused writing</title>
     <meta name="description" content="Earnesty is a clean, distraction-free writing app. Write, save, and revisit your work in a calm and focused environment.">
 

--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -17,13 +17,13 @@
   ],
   "responseOverrides": {
     "401": {
-      "redirect": "/.auth/login/aad",
+      "redirect": "/.auth/login/aad?post_login_redirect_uri=/",
       "statusCode": 302
     }
   },
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/assets/*", "/favicon.ico"]
+    "exclude": ["/assets/*", "/favicon*", "/.auth/*"]
   },
   "globalHeaders": {
     "X-Content-Type-Options": "nosniff",

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -17,7 +17,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   function login() {
-    window.location.href = '/.auth/login/aad'
+    window.location.href = '/.auth/login/aad?post_login_redirect_uri=/'
   }
 
   function logout() {


### PR DESCRIPTION
## Theme flash on menu hover

The menu bar appeared in light mode on first hover because `data-theme` is only set after Pinia initialises. Added an inline `<script>` in `index.html` that reads `localStorage` and sets `data-theme` synchronously before first paint — the standard fix for theme FOUC.

## Auth blank page

Added `?post_login_redirect_uri=/` to the `/.auth/login/aad` URL in the auth store and the 401 response override, so SWA knows to redirect back to the app after a successful login.

Also excluded `/.auth/*` from the `navigationFallback` to prevent the Vue SPA from accidentally intercepting auth routes.