### PR TITLE
ci: trigger deploy workflow on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy to Azure Static Web Apps
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The deploy workflow previously only ran on manual `workflow_dispatch`. Now it also triggers automatically on every push to `main`, so merging a PR deploys to Azure Static Web Apps immediately.

One-line change to `.github/workflows/deploy.yml`.