### PR TITLE
style: improve settings menu button layout

### DIFF
--- a/app/src/components/SettingsModal.vue
+++ b/app/src/components/SettingsModal.vue
@@ -137,6 +137,7 @@ const widthLabels: Record<number, string> = {
 
 .settings__choices {
   display: flex;
+  flex: 1;
   border: 1px solid var(--ctp-surface1);
   border-radius: 6px;
   overflow: hidden;
@@ -151,6 +152,7 @@ const widthLabels: Record<number, string> = {
   color: var(--ctp-subtext1);
   font-size: 0.82rem;
   white-space: nowrap;
+  text-align: center;
   cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease;
 }


### PR DESCRIPTION
## Summary

Fixes the settings modal button layout so all choice groups are uniform and readable.

### Changes

- **No line breaks**: `white-space: nowrap` prevents labels like "Sans Serif" and "Comic Sans" from wrapping
- **Equal widths**: All segmented-control groups stretch to the same width (`flex: 1` on the container)
- **Center aligned**: Button labels are centered within each segment