### PR TITLE
ci: add Dependabot weekly update config with cooldown and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  # ── Frontend app (Vue/Vite) ─────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-app:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 3
+
+  # ── API (Azure Functions) ───────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/app/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-api:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 3
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────────
+  # Monitors action versions pinned with `uses:` in .github/workflows/*.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to configure automated dependency updates for all supported ecosystems.

## Ecosystems covered

| Ecosystem | Directory | What it watches |
|---|---|---|
| `npm` | `/app` | Frontend Vue/Vite dependencies |
| `npm` | `/app/api` | Azure Functions API dependencies |
| `github-actions` | `/` | `uses:` pins in `.github/workflows/*.yml` |

> **Note:** `infra/` uses Azure Bicep, which Dependabot does not currently support as a package ecosystem.

## Key settings

- **Weekly on Mondays** — avoids daily noise while keeping dependencies reasonably fresh.
- **Grouped PRs** — one PR per ecosystem per run (e.g. all `/app` npm bumps in a single PR) rather than one PR per package.
- **3-day cooldown (`default-days: 3`)** — Dependabot skips any package released within the last 72 hours. This guards against dependency-confusion and fast-follower supply-chain attacks, where a malicious package is uploaded immediately after a legitimate release.
- **Conventional Commits prefix** — commit messages use `chore(deps):` / `chore(deps-dev):` to match the project's commit style and to avoid triggering a release-please version bump.