### PR TITLE
ci: deploy infra then app sequentially on every push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Azure Static Web Apps
+name: Deploy to Azure
 
 on:
   push:
@@ -6,14 +6,60 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
+# Skip deployment when release-please merges its version-bump PR — those commits
+# contain only changelog/version changes and the app was already deployed when the
+# underlying feature PRs were merged. The commit format is:
+#   chore(main): release <package> <version>
+# The || '' guard handles workflow_dispatch where head_commit is absent (null).
 jobs:
-  build-and-deploy:
-    name: Build and Deploy
+  deploy-infra:
+    name: Deploy Infrastructure
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message || '', 'chore(main): release')
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy infrastructure
+        run: |
+          az stack sub create \
+            --name "earnesty" \
+            --location "${{ vars.AZURE_LOCATION || 'westeurope' }}" \
+            --template-file infra/main.bicep \
+            --parameters \
+              location="${{ vars.AZURE_LOCATION || 'westeurope' }}" \
+              staticWebAppSku="${{ vars.STATIC_WEB_APP_SKU || 'Standard' }}" \
+              entraClientId="${{ secrets.ENTRA_CLIENT_ID }}" \
+              entraClientSecret="${{ secrets.ENTRA_CLIENT_SECRET }}" \
+              entraTenantId="${{ secrets.ENTRA_TENANT_ID }}" \
+              sanityToken="${{ secrets.SANITY_TOKEN }}" \
+              sanityProjectId="${{ secrets.SANITY_PROJECT_ID }}" \
+              sanityDataset="${{ secrets.SANITY_DATASET }}" \
+            --deny-settings-mode none \
+            --action-on-unmanage detachAll \
+            --yes
+
+  deploy-app:
+    name: Build and Deploy App
+    needs: deploy-infra
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,6 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs['app--release_created'] }}
-      tag_name: ${{ steps.release.outputs['app--tag_name'] }}
 
     steps:
       - uses: googleapis/release-please-action@v4.4.0
@@ -24,85 +21,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  deploy-infra:
-    name: Deploy Infrastructure
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy infrastructure
-        run: |
-          az stack sub create \
-            --name "earnesty" \
-            --location "${{ vars.AZURE_LOCATION || 'westeurope' }}" \
-            --template-file infra/main.bicep \
-            --parameters \
-              location="${{ vars.AZURE_LOCATION || 'westeurope' }}" \
-              staticWebAppSku="${{ vars.STATIC_WEB_APP_SKU || 'Standard' }}" \
-              entraClientId="${{ secrets.ENTRA_CLIENT_ID }}" \
-              entraClientSecret="${{ secrets.ENTRA_CLIENT_SECRET }}" \
-              entraTenantId="${{ secrets.ENTRA_TENANT_ID }}" \
-              sanityToken="${{ secrets.SANITY_TOKEN }}" \
-              sanityProjectId="${{ secrets.SANITY_PROJECT_ID }}" \
-              sanityDataset="${{ secrets.SANITY_DATASET }}" \
-            --deny-settings-mode none \
-            --action-on-unmanage detachAll \
-            --yes
-
-  deploy-app:
-    name: Build and Deploy App
-    needs: [release-please, deploy-infra]
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: app/package-lock.json
-
-      - name: Install dependencies
-        working-directory: app
-        run: npm ci
-
-      - name: Build
-        working-directory: app
-        env:
-          VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
-          VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
-        run: npm run build
-
-      - name: Deploy to Azure Static Web Apps
-        uses: azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: upload
-          app_location: app/dist
-          api_location: app/api
-          output_location: ""
-          skip_app_build: true


### PR DESCRIPTION
## What

Consolidates deployment into a single sequential pipeline triggered on every push to `main`, and removes the release-triggered deployment from `release-please.yml`.

## Behaviour after this change

| Event | deploy-infra | deploy-app |
|---|---|---|
| Feature PR merged → push to main | ✅ runs | ✅ runs (after infra) |
| release-please PR merged → `chore(main): release ...` | ⏭ skipped | ⏭ skipped (needs skipped) |
| Manual `workflow_dispatch` | ✅ runs | ✅ runs (after infra) |

### Why skip on release-please commits?

The release-please PR contains only a version bump and changelog update — no application code changes. The app was already deployed when each feature PR was merged to main. Running a second deployment for the release commit would be redundant.

### Why deploy infra on every push?

The Bicep stack is idempotent (`az stack sub create` is a no-op when nothing changed), so running it on every push is safe. It ensures infra drift is corrected automatically rather than waiting for a manual run.

## Files changed

- **`.github/workflows/deploy.yml`** — rewritten: two sequential jobs (`deploy-infra` → `deploy-app`), release-please skip guard with `|| ''` null guard for `workflow_dispatch`
- **`.github/workflows/release-please.yml`** — stripped to just the `release-please` job; deploy jobs removed
- **`.github/workflows/deploy-infra.yml`** — unchanged; remains available as a manual escape hatch with `location`/`sku` inputs