### PR TITLE
fix: convert markdown link syntax on paste to proper links

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -232,8 +232,18 @@ const tiptap = useEditor({
       return true
     },
     handlePaste(_view, event) {
-      // Handle markdown link syntax: [text](url)
       const text = event.clipboardData?.getData('text/plain') ?? ''
+      const editor = tiptap.value
+      if (!editor) return false
+
+      // Select text + paste a URL → wrap selection as a link
+      if (!editor.state.selection.empty && /^https?:\/\/\S+$/.test(text.trim())) {
+        event.preventDefault()
+        editor.chain().focus().setLink({ href: text.trim() }).run()
+        return true
+      }
+
+      // Handle markdown link syntax: [text](url)
       const mdLinkRe = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
       if (mdLinkRe.test(text)) {
         event.preventDefault()
@@ -257,7 +267,7 @@ const tiptap = useEditor({
           content.push({ type: 'text', text: text.slice(lastIndex) })
         }
 
-        tiptap.value?.chain().focus().insertContent(content).run()
+        editor.chain().focus().insertContent(content).run()
         return true
       }
 

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -232,6 +232,36 @@ const tiptap = useEditor({
       return true
     },
     handlePaste(_view, event) {
+      // Handle markdown link syntax: [text](url)
+      const text = event.clipboardData?.getData('text/plain') ?? ''
+      const mdLinkRe = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
+      if (mdLinkRe.test(text)) {
+        event.preventDefault()
+        mdLinkRe.lastIndex = 0
+
+        const content: Array<Record<string, unknown>> = []
+        let lastIndex = 0
+        let match
+        while ((match = mdLinkRe.exec(text)) !== null) {
+          if (match.index > lastIndex) {
+            content.push({ type: 'text', text: text.slice(lastIndex, match.index) })
+          }
+          content.push({
+            type: 'text',
+            text: match[1],
+            marks: [{ type: 'link', attrs: { href: match[2] } }],
+          })
+          lastIndex = match.index + match[0].length
+        }
+        if (lastIndex < text.length) {
+          content.push({ type: 'text', text: text.slice(lastIndex) })
+        }
+
+        tiptap.value?.chain().focus().insertContent(content).run()
+        return true
+      }
+
+      // Handle pasted images
       const file = Array.from(event.clipboardData?.files ?? []).find((f) =>
         f.type.startsWith('image/'),
       )


### PR DESCRIPTION
Improves link creation when pasting in the editor.

**What changed:**

1. **Select text + paste URL → creates link**: When text is selected and a URL is pasted from the clipboard, the selected text is wrapped as a clickable link instead of being replaced.

2. **Markdown link syntax on paste**: When pasting text containing `[text](url)` markdown syntax, it's converted into proper clickable links instead of raw text. Handles multiple links and surrounding text.

Both features are checked before the existing image paste handler. Regular URL autolink continues to work as before.

**Examples:**
- Select "click here" → paste `https://example.com` → "click here" becomes a link
- Paste `[Google](https://google.com)` → inserts "Google" as a clickable link