### PR TITLE
ci: deploy PR preview environments on Azure Static Web Apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,22 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
 
     steps:
       - name: Checkout
@@ -47,3 +53,17 @@ jobs:
           api_location: app/api
           output_location: ""
           skip_app_build: true
+
+  close-preview:
+    name: Close Preview Environment
+    runs-on: ubuntu-latest
+    environment: preview
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+
+    steps:
+      - name: Close Pull Request Preview
+        uses: azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: close
+          app_location: "/"


### PR DESCRIPTION
## Summary

Adds PR preview environment deployments via Azure Static Web Apps.

## Changes

- **`deploy.yml`** — extended to trigger on `pull_request` events (opened, synchronize, reopened, closed) targeting `main`
  - `build-and-deploy` job uses `preview` GitHub environment for PR builds and `production` for push/dispatch
  - Job is skipped when a PR is closed
  - `pull-requests: write` permission added so the Azure action can post the preview URL as a PR comment
  - New `close-preview` job runs `action: close` when a PR is closed, tearing down the preview environment

## ⚠️ Non-conventional commit

This branch contains a commit titled **`Initial plan`** which does not follow the conventional commits format required by this repository. This commit should be amended or squashed before merging.

## Notes

This branch was created by a Copilot coding agent. The `Initial plan` commit is an agent artefact and should be squashed into the CI commit before merging.