### PR TITLE
feat: improve publish button with flush mechanism, tooltip, and indicator dot

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -39,9 +39,25 @@ const canPublish = computed(() =>
   auth.isAuthenticated
   && !!editorStore.activeDocument
   && editorStore.activeDocument._id.startsWith('drafts.')
-  && editorStore.saveStatus !== 'saving'
   && editorStore.publishStatus !== 'publishing',
 )
+
+const isDraft = computed(() =>
+  !!editorStore.activeDocument
+  && editorStore.activeDocument._id.startsWith('drafts.'),
+)
+
+const isMac = navigator.platform.toUpperCase().includes('MAC')
+const publishShortcut = isMac ? '⌘⇧P' : 'Ctrl+Shift+P'
+
+const publishTooltip = computed(() => {
+  if (!auth.isAuthenticated) return 'Sign in to publish'
+  if (!editorStore.activeDocument) return 'No document open'
+  if (!isDraft.value) return 'No new changes'
+  if (editorStore.publishStatus === 'publishing') return 'Publishing…'
+  if (editorStore.saveStatus === 'saving') return `Saving… (${publishShortcut})`
+  return publishShortcut
+})
 
 async function publishDocument() {
   if (!canPublish.value) return
@@ -78,6 +94,9 @@ async function onPublishConfirm(meta: DocumentMeta) {
 async function doPublish() {
   const doc = editorStore.activeDocument
   if (!doc) return
+
+  // Flush any pending autosave so we publish the latest content
+  if (editorStore.flushSave) await editorStore.flushSave()
 
   editorStore.setPublishStatus('publishing')
   try {
@@ -122,6 +141,8 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
     :is-authenticated="auth.isAuthenticated"
     :has-document="!!editorStore.activeDocument"
     :can-publish="canPublish"
+    :is-draft="isDraft"
+    :publish-tooltip="publishTooltip"
     @new="editorStore.resetToPlaceholder()"
     @open="showOpen = true"
     @publish="publishDocument"

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -16,6 +16,8 @@ const props = defineProps<{
   isAuthenticated?: boolean
   hasDocument?: boolean
   canPublish?: boolean
+  isDraft?: boolean
+  publishTooltip?: string
 }>()
 
 const statusLabel = computed(() => {
@@ -56,12 +58,16 @@ const shortcuts: Record<string, string> = {
 }
 
 function onEnter(key: string, e: MouseEvent) {
-  const label = shortcuts[key] ?? key
+  const label = key === 'publish' && props.publishTooltip
+    ? props.publishTooltip
+    : shortcuts[key] ?? key
   tooltip.value = { label, x: e.clientX, y: e.clientY }
 }
 function onMove(key: string, e: MouseEvent) {
   if (tooltip.value) {
-    const label = shortcuts[key] ?? key
+    const label = key === 'publish' && props.publishTooltip
+      ? props.publishTooltip
+      : shortcuts[key] ?? key
     tooltip.value = { label, x: e.clientX, y: e.clientY }
   }
 }
@@ -189,6 +195,11 @@ function onLeave() {
           @mouseleave="onLeave"
         >
           Publish
+          <span
+            v-if="isDraft && canPublish"
+            class="menubar__publish-dot"
+            aria-label="Unpublished changes"
+          />
         </button>
       </div>
 
@@ -373,6 +384,11 @@ function onLeave() {
           @click="canPublish && mobileEmit('publish')"
         >
           Publish
+          <span
+            v-if="isDraft && canPublish"
+            class="menubar__publish-dot"
+            aria-label="Unpublished changes"
+          />
         </button>
         <button
           role="menuitem"
@@ -545,6 +561,22 @@ function onLeave() {
 .menubar__item--publish:hover {
   background: color-mix(in srgb, var(--ctp-green) 15%, transparent);
   color: var(--ctp-green);
+}
+
+.menubar__publish-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ctp-green);
+  margin-left: var(--space-3xs);
+  vertical-align: middle;
+  animation: dot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 .menubar__item--disabled {

--- a/app/src/stores/editor.ts
+++ b/app/src/stores/editor.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import type { BlogDocument } from '../services/sanity'
 import { INTRO_HTML } from '../constants'
 
@@ -54,6 +54,9 @@ export const useEditorStore = defineStore('editor', () => {
   const meta = ref<DocumentMeta>(
     saved?.meta ?? { title: '', slug: '', publishedAt: '', tags: [] },
   )
+
+  /** Registered by HomeView to flush pending autosave before publish. */
+  const flushSave = shallowRef<(() => Promise<void>) | null>(null)
 
   function openDocument(doc: BlogDocument, html?: string) {
     activeDocument.value = doc
@@ -120,6 +123,7 @@ export const useEditorStore = defineStore('editor', () => {
     saveStatus,
     publishStatus,
     meta,
+    flushSave,
     openDocument,
     clearDocument,
     resetToPlaceholder,

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -47,8 +47,16 @@ const AUTOSAVE_DELAY = 1500
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 let latestJson: TiptapNode | null = null
 let creatingDraft = false
+let currentSavePromise: Promise<void> | null = null
 
 const INTRO_TITLE = 'Earnesty is your space for focused writing'
+
+// Register flushSave so App.vue can drain pending saves before publish
+editorStore.flushSave = async () => {
+  if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
+  if (latestJson) await doAutosave()
+  if (currentSavePromise) await currentSavePromise
+}
 
 // ── Image picker ───────────────────────────────────────────────────────────────
 const showImagePicker = ref(false)
@@ -103,55 +111,61 @@ async function doAutosave() {
   if (!json || !auth.isAuthenticated) return
   latestJson = null
 
-  // Auto-create a draft document on the first save
-  if (!editorStore.activeDocument) {
-    if (creatingDraft) {
-      // Re-queue so latest content isn't dropped
-      latestJson = json
-      return
+  const run = async () => {
+    // Auto-create a draft document on the first save
+    if (!editorStore.activeDocument) {
+      if (creatingDraft) {
+        // Re-queue so latest content isn't dropped
+        latestJson = json
+        return
+      }
+      creatingDraft = true
+      editorStore.setSaveStatus('saving')
+      try {
+        let titleText = extractTitleText(json)
+        if (!titleText || titleText === INTRO_TITLE) titleText = 'Untitled'
+        const slug = editorStore.slugify(titleText) || 'untitled'
+        const doc = await apiCreateDraft(titleText, slug)
+        // Guard against stale completion: user may have opened another doc
+        if (!editorStore.activeDocument) {
+          editorStore.openDocument(doc)
+          trackEvent('draft_created', { documentId: doc._id })
+        }
+      } catch (err) {
+        console.error('[autosave] draft creation failed:', err)
+        editorStore.setSaveStatus('error')
+        trackException(err instanceof Error ? err : new Error(String(err)), { action: 'create_draft' })
+        return
+      } finally {
+        creatingDraft = false
+        // If edits arrived during creation, re-trigger save
+        if (latestJson) setTimeout(() => doAutosave(), 0)
+      }
     }
-    creatingDraft = true
+
+    const doc = editorStore.activeDocument
+    if (!doc) return
+
     editorStore.setSaveStatus('saving')
     try {
-      let titleText = extractTitleText(json)
-      if (!titleText || titleText === INTRO_TITLE) titleText = 'Untitled'
-      const slug = editorStore.slugify(titleText) || 'untitled'
-      const doc = await apiCreateDraft(titleText, slug)
-      // Guard against stale completion: user may have opened another doc
-      if (!editorStore.activeDocument) {
-        editorStore.openDocument(doc)
-        trackEvent('draft_created', { documentId: doc._id })
-      }
+      const titleText = extractTitleText(json)
+      const bodyJson = { ...json, content: json.content?.slice(1) ?? [] }
+      await apiSaveDocument(doc._id, tiptapJsonToPortableText(bodyJson), titleText || undefined)
+      editorStore.setSaveStatus('saved')
+      trackEvent('document_saved', { documentId: doc._id })
     } catch (err) {
-      console.error('[autosave] draft creation failed:', err)
+      console.error('[autosave] failed:', err)
       editorStore.setSaveStatus('error')
-      trackException(err instanceof Error ? err : new Error(String(err)), { action: 'create_draft' })
-      return
+      trackException(err instanceof Error ? err : new Error(String(err)), { action: 'autosave' })
     } finally {
-      creatingDraft = false
-      // If edits arrived during creation, re-trigger save
+      // If edits arrived during save, re-trigger
       if (latestJson) setTimeout(() => doAutosave(), 0)
     }
   }
 
-  const doc = editorStore.activeDocument
-  if (!doc) return
-
-  editorStore.setSaveStatus('saving')
-  try {
-    const titleText = extractTitleText(json)
-    const bodyJson = { ...json, content: json.content?.slice(1) ?? [] }
-    await apiSaveDocument(doc._id, tiptapJsonToPortableText(bodyJson), titleText || undefined)
-    editorStore.setSaveStatus('saved')
-    trackEvent('document_saved', { documentId: doc._id })
-  } catch (err) {
-    console.error('[autosave] failed:', err)
-    editorStore.setSaveStatus('error')
-    trackException(err instanceof Error ? err : new Error(String(err)), { action: 'autosave' })
-  } finally {
-    // If edits arrived during save, re-trigger
-    if (latestJson) setTimeout(() => doAutosave(), 0)
-  }
+  currentSavePromise = run()
+  await currentSavePromise
+  currentSavePromise = null
 }
 
 function extractTitleText(doc: TiptapNode): string {
@@ -284,6 +298,7 @@ async function handleImageFile(file: File) {
 onBeforeUnmount(() => {
   tiptap.value?.destroy()
   if (saveTimer) clearTimeout(saveTimer)
+  editorStore.flushSave = null
 })
 
 // ── Load document from store ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Improves the publish button experience in three ways:

1. **Race condition fix**: Removes the `saveStatus !== 'saving'` gate from `canPublish` so the button stays enabled while autosave is debouncing. Publishing when a save is in-flight previously risked losing the latest edits.

2. **Flush mechanism**: Before publishing, `doPublish()` now calls `editorStore.flushSave()` — a callback registered by `HomeView` that cancels any pending debounce timer and awaits any in-progress save. This ensures the latest unsaved content is always committed before the document is published.

3. **Tooltip and indicator dot**: The publish button shows a context-sensitive tooltip (keyboard shortcut, saving state, or reason it's disabled) and a pulsing green dot when the document has unpublished draft changes.

## Changes

- `App.vue` — removes `saveStatus` from `canPublish`, adds `isDraft` computed, builds `publishTooltip`, calls `flushSave` before publish
- `AppMenuBar.vue` — accepts `isDraft` and `publishTooltip` props; renders indicator dot and tooltip for publish button
- `editor.ts` (store) — adds `flushSave: ShallowRef` so `HomeView` can register the flush callback
- `HomeView.vue` — wraps `doAutosave` body in a tracked promise (`currentSavePromise`), registers `flushSave` callback on mount, clears it on unmount