### PR TITLE
ci: add path filters to deployment workflows

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,6 +1,15 @@
 name: Deploy Infrastructure
 
 on:
+  # Automatically deploy when infra files change on main.
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+  # Manual trigger allows choosing a custom region or SKU (e.g. first-time
+  # provisioning or migrating to a different region). When triggered manually,
+  # inputs.location / inputs.sku override the repository variables.
   workflow_dispatch:
     inputs:
       location:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,61 +1,25 @@
 name: Deploy to Azure
 
 on:
+  # Only run when app files change — infra is deployed by deploy-infra.yml.
   push:
     branches:
       - main
+    paths:
+      - 'app/**'
   workflow_dispatch:
 
-# Skip deployment when release-please merges its version-bump PR — those commits
-# contain only changelog/version changes and the app was already deployed when the
-# underlying feature PRs were merged. The commit format is:
-#   chore(main): release <package> <version>
-# The || '' guard handles workflow_dispatch where head_commit is absent (null).
 jobs:
-  deploy-infra:
-    name: Deploy Infrastructure
+  deploy-app:
+    name: Build and Deploy App
+    # Skip deployment when release-please merges its version-bump PR — those commits
+    # contain only changelog/version changes and the app was already deployed when the
+    # underlying feature PRs were merged. The commit format is:
+    #   chore(main): release <package> <version>
+    # The || '' guard handles workflow_dispatch where head_commit is absent (null).
     if: >
       github.event_name == 'workflow_dispatch' ||
       !startsWith(github.event.head_commit.message || '', 'chore(main): release')
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Azure login
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy infrastructure
-        run: |
-          az stack sub create \
-            --name "earnesty" \
-            --location "${{ vars.AZURE_LOCATION || 'westeurope' }}" \
-            --template-file infra/main.bicep \
-            --parameters \
-              location="${{ vars.AZURE_LOCATION || 'westeurope' }}" \
-              staticWebAppSku="${{ vars.STATIC_WEB_APP_SKU || 'Standard' }}" \
-              entraClientId="${{ secrets.ENTRA_CLIENT_ID }}" \
-              entraClientSecret="${{ secrets.ENTRA_CLIENT_SECRET }}" \
-              entraTenantId="${{ secrets.ENTRA_TENANT_ID }}" \
-              sanityToken="${{ secrets.SANITY_TOKEN }}" \
-              sanityProjectId="${{ secrets.SANITY_PROJECT_ID }}" \
-              sanityDataset="${{ secrets.SANITY_DATASET }}" \
-            --deny-settings-mode none \
-            --action-on-unmanage detachAll \
-            --yes
-
-  deploy-app:
-    name: Build and Deploy App
-    needs: deploy-infra
     runs-on: ubuntu-latest
     environment: production
     permissions:


### PR DESCRIPTION
## Summary

Adds path-based triggers to deployment workflows so they only run when relevant files change.

## Changes

### `deploy-infra.yml`
- Added automatic `push` trigger scoped to `infra/**` path changes on `main`
- This replaces the duplicate infra deploy step that previously lived in `deploy.yml`
- `workflow_dispatch` retains its custom `location`/`sku` inputs for manual deployments

### `deploy.yml`
- Now app-only: scoped to `app/**` path changes on `main`
- Removed the `deploy-infra` job (no longer needed — handled by `deploy-infra.yml`)
- Removed the `needs: deploy-infra` coupling from `deploy-app`
- Moved the release-please skip guard onto the `deploy-app` job

## Why the duplicate existed

`deploy-infra.yml` is the **manual escape hatch** for deploying infra with a custom region or SKU (e.g. first-time provisioning). `deploy.yml` had a copy of the infra step to ensure infra was always in sync on every push to `main`. The duplication created a maintenance risk — Bicep parameter changes needed to be applied in both files.

By adding a `paths: ['infra/**']` trigger to `deploy-infra.yml`, both manual and automatic infra deploys are handled by one workflow, and the duplication is resolved.