### PR TITLE
feat: make app configurable and remove hardcoded backend couplings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ A minimal, focused writing environment built with [Vue 3](https://vuejs.org) and
    cp app/.env.example app/.env
    ```
 
-   Edit `app/.env`:
+   Edit `app/.env` and fill in your Sanity project details:
 
    ```env
    VITE_SANITY_PROJECT_ID=your_project_id
-   VITE_SANITY_DATASET=dev
-   VITE_SANITY_TOKEN=your_sanity_token
+   VITE_SANITY_DATASET=production
    ```
+
+   The Sanity write token (`SANITY_TOKEN`) is consumed server-side by the API
+   functions and must **not** be set as a `VITE_` variable — doing so would
+   expose it in the browser bundle. For local development with the SWA CLI,
+   configure it in `app/api/local.settings.json` or as an environment variable
+   in your shell before starting the SWA CLI.
 
 3. **Start the dev server**
 
@@ -56,6 +61,73 @@ cd app && npm run build
 
 Output is written to `app/dist/`.
 
+## Self-hosting
+
+These are the minimum steps to run Earnesty against your own Sanity project.
+
+### 1 — Create a Sanity project
+
+1. Go to <https://sanity.io/manage> and create a new project (the free tier is sufficient)
+2. Note your **project ID** and create a dataset (e.g. `production`)
+3. Create an API token with **Editor** permissions — this is `SANITY_TOKEN`
+
+### 2 — Apply the schema
+
+Copy `docs/sanity-schema.ts` into your Sanity Studio's `schemaTypes/` directory and register it:
+
+```ts
+// schemaTypes/index.ts
+import { blogType } from './earnesty-schema'
+export const schemaTypes = [blogType]
+```
+
+The schema requires the `@sanity/code-input` plugin for code block support:
+
+```sh
+npm install @sanity/code-input
+```
+
+```ts
+// sanity.config.ts
+import { codeInput } from '@sanity/code-input'
+export default defineConfig({ plugins: [codeInput()] })
+```
+
+If you prefer a different document type name than `blog`, rename `blogType`'s `name` field and set the `VITE_SANITY_DOCUMENT_TYPE` / `SANITY_DOCUMENT_TYPE` environment variables to match.
+
+### 3 — Environment variables
+
+All environment variables with their defaults:
+
+| Variable | Where consumed | Required | Default | Description |
+|----------|---------------|----------|---------|-------------|
+| `VITE_SANITY_PROJECT_ID` | Frontend (build-time) | ✅ | — | Sanity project ID |
+| `VITE_SANITY_DATASET` | Frontend (build-time) | ✅ | — | Sanity dataset name |
+| `VITE_SANITY_DOCUMENT_TYPE` | Frontend (build-time) | | `blog` | Document type to read and write |
+| `VITE_AUTH_LOGIN_URL` | Frontend (build-time) | | `/.auth/login/aad` | SWA login redirect URL |
+| `VITE_AUTH_LOGOUT_URL` | Frontend (build-time) | | `/.auth/logout` | SWA logout redirect URL |
+| `VITE_AUTH_ME_URL` | Frontend (build-time) | | `/.auth/me` | SWA current-user endpoint |
+| `VITE_APPLICATIONINSIGHTS_CONNECTION_STRING` | Frontend (build-time) | | — | Azure Application Insights (omit to disable) |
+| `SANITY_TOKEN` | API (runtime) | ✅ | — | Sanity write token — **never** set as a `VITE_` variable |
+| `SANITY_PROJECT_ID` | API (runtime) | ✅ | — | Sanity project ID (server-side copy) |
+| `SANITY_DATASET` | API (runtime) | ✅ | — | Sanity dataset name (server-side copy) |
+| `SANITY_DOCUMENT_TYPE` | API (runtime) | | `blog` | Document type — must match `VITE_SANITY_DOCUMENT_TYPE` |
+
+### 4 — Authentication
+
+The app uses [Azure Static Web Apps built-in authentication](https://learn.microsoft.com/azure/static-web-apps/authentication-authorization). By default it is configured for **Azure Active Directory** (`aad`). To switch provider, change `VITE_AUTH_LOGIN_URL`:
+
+| Provider | `VITE_AUTH_LOGIN_URL` |
+|----------|----------------------|
+| Microsoft Entra ID (default) | `/.auth/login/aad` |
+| GitHub | `/.auth/login/github` |
+| Google | `/.auth/login/google` |
+| X / Twitter | `/.auth/login/twitter` |
+
+See the [Entra ID App Registration](#entra-id-app-registration) section below for the Azure-specific setup.
+
+---
+
 ## GitHub environments
 
 The CI/CD pipelines use two GitHub environments to keep dev and production configuration separate.
@@ -79,7 +151,7 @@ Configure the following secrets on **each environment** (not at repository level
 |--------|-------------|
 | `VITE_SANITY_PROJECT_ID` | Sanity project ID |
 | `VITE_SANITY_DATASET` | Sanity dataset name (e.g. `dev`) |
-| `VITE_SANITY_TOKEN` | Sanity API token with read/write access |
+| `VITE_SANITY_TOKEN` | Sanity API token — used by integration tests as `SANITY_TOKEN` (the `VITE_` prefix is just a historical secret name; this value is never exposed to the browser) |
 
 #### `production` environment
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,6 +1,32 @@
-# Sanity.io project configuration (read-only, public)
+# ── Sanity.io ─────────────────────────────────────────────────────────────────
+# Project ID and dataset (build-time, public — safe to commit if you like).
+# Find these in https://www.sanity.io/manage under your project.
 VITE_SANITY_PROJECT_ID=your_project_id
-VITE_SANITY_DATASET=dev
-# Write operations are handled server-side by the SWA API backend.
-# The Sanity API token is configured as an SWA app setting (SANITY_TOKEN),
-# not as a VITE_ env var — it must never be exposed to the browser.
+VITE_SANITY_DATASET=production
+
+# Sanity document type the app reads and writes (default: blog).
+# Change this if your Studio schema uses a different type name (e.g. "post").
+# Must match SANITY_DOCUMENT_TYPE set in the API / Azure Functions environment.
+# VITE_SANITY_DOCUMENT_TYPE=blog
+
+# ── Authentication ────────────────────────────────────────────────────────────
+# Azure Static Web Apps built-in auth endpoints.
+# Defaults to Azure Active Directory (aad). Change the provider segment to use
+# a different SWA-supported identity provider: github, google, twitter, etc.
+# Omit these lines entirely to use the defaults.
+# VITE_AUTH_LOGIN_URL=/.auth/login/aad
+# VITE_AUTH_LOGOUT_URL=/.auth/logout
+# VITE_AUTH_ME_URL=/.auth/me
+
+# ── Observability (optional) ──────────────────────────────────────────────────
+# Azure Application Insights telemetry. Omit to disable telemetry entirely.
+# VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=...
+
+# ── API / Azure Functions (server-side, NOT prefixed with VITE_) ──────────────
+# These are set as Azure SWA application settings, NOT in this file.
+# They are listed here for reference only.
+#
+# SANITY_TOKEN=your_sanity_write_token   (required — never expose as VITE_)
+# SANITY_PROJECT_ID=your_project_id      (same value as VITE_SANITY_PROJECT_ID)
+# SANITY_DATASET=production              (same value as VITE_SANITY_DATASET)
+# SANITY_DOCUMENT_TYPE=blog              (same value as VITE_SANITY_DOCUMENT_TYPE)

--- a/app/api/src/__tests__/listDocuments.test.ts
+++ b/app/api/src/__tests__/listDocuments.test.ts
@@ -97,14 +97,16 @@ describe('listDocuments handler', () => {
     expect(res.jsonBody).toEqual({ error: 'Failed to list documents' })
   })
 
-  it('passes a GROQ query that filters by blog type', async () => {
+  it('passes a GROQ query that filters by document type', async () => {
     const mockFetch = vi.fn().mockResolvedValue([])
     vi.mocked(getSanityClient).mockReturnValue({ fetch: mockFetch } as any)
 
     await getHandler()(makeRequest())
 
     const query = mockFetch.mock.calls[0][0] as string
-    expect(query).toContain('_type == "blog"')
+    const params = mockFetch.mock.calls[0][1] as Record<string, unknown>
+    expect(query).toContain('_type == $docType')
+    expect(params).toMatchObject({ docType: 'blog' })
     expect(query).toContain('order(')
   })
 })

--- a/app/api/src/functions/createDraft.ts
+++ b/app/api/src/functions/createDraft.ts
@@ -33,11 +33,13 @@ app.http('createDraft', {
       return { status: 400, jsonBody: { error: '"slug" is required' } }
     }
 
+    const docType = process.env['SANITY_DOCUMENT_TYPE'] ?? 'blog'
+
     try {
       const id = `drafts.${crypto.randomUUID()}`
       const doc = await getSanityClient().create({
         _id: id,
-        _type: 'blog',
+        _type: docType,
         title: body.title.trim(),
         slug: { _type: 'slug', current: body.slug.trim() },
       })

--- a/app/api/src/functions/listDocuments.ts
+++ b/app/api/src/functions/listDocuments.ts
@@ -19,9 +19,11 @@ app.http('listDocuments', {
       return { status: 401, jsonBody: { error: 'Not authenticated' } }
     }
 
+    const docType = process.env['SANITY_DOCUMENT_TYPE'] ?? 'blog'
+
     try {
       const docs = await getSanityClient().fetch(
-        `*[_type == "blog"] | order(coalesce(publishedAt, _createdAt) desc) {
+        `*[_type == $docType] | order(coalesce(publishedAt, _createdAt) desc) {
           _id,
           _createdAt,
           _updatedAt,
@@ -29,6 +31,7 @@ app.http('listDocuments', {
           title,
           "body": body[_type == "block"][0..10]
         }`,
+        { docType },
       )
       return { status: 200, jsonBody: docs }
     } catch (err) {

--- a/app/src/services/__tests__/sanity.test.ts
+++ b/app/src/services/__tests__/sanity.test.ts
@@ -455,8 +455,10 @@ describe('fetchBlogDocuments', () => {
     await fetchBlogDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
+    const params = mockClientFetch.mock.calls[0][1] as Record<string, unknown>
     expect(query).toMatch(/^\s*\*\[/)
-    expect(query).toContain('_type == "blog"')
+    expect(query).toContain('_type == $docType')
+    expect(params).toMatchObject({ docType: 'blog' })
   })
 
   it('orders results by published date descending', async () => {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -8,7 +8,7 @@ export interface ImageAsset {
   height: number | null
 }
 
-const LOGIN_PATH = '/.auth/login/aad'
+const LOGIN_PATH = import.meta.env.VITE_AUTH_LOGIN_URL ?? '/.auth/login/aad'
 const REDIRECT_COOLDOWN_MS = 10_000
 const REDIRECT_TS_KEY = '__auth_redirect_ts'
 
@@ -124,7 +124,7 @@ export async function apiListImages(): Promise<ImageAsset[]> {
 /** Fetches the current user from the SWA auth endpoint. */
 export async function apiGetUser(): Promise<SwaUser | null> {
   try {
-    const res = await fetch('/.auth/me')
+    const res = await fetch(import.meta.env.VITE_AUTH_ME_URL ?? '/.auth/me')
     if (!res.ok) return null
     const data = (await res.json()) as { clientPrincipal: SwaUser | null }
     return data.clientPrincipal

--- a/app/src/services/sanity.ts
+++ b/app/src/services/sanity.ts
@@ -324,24 +324,27 @@ function key() {
 
 // ── Queries ───────────────────────────────────────────────────────────────────
 
+const DOCUMENT_TYPE = import.meta.env.VITE_SANITY_DOCUMENT_TYPE ?? 'blog'
+
 /** Fetch list of blog documents (title + enough body blocks for 50-word preview). */
 export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
-  return sanityClient.fetch(`
-    *[_type == "blog"] | order(coalesce(publishedAt, _createdAt) desc) {
+  return sanityClient.fetch(
+    `*[_type == $docType] | order(coalesce(publishedAt, _createdAt) desc) {
       _id,
       _createdAt,
       _updatedAt,
       publishedAt,
       title,
       "body": body[_type == "block"][0..10]
-    }
-  `)
+    }`,
+    { docType: DOCUMENT_TYPE },
+  )
 }
 
 /** Fetch the full body of a single document for editing. */
 export async function fetchBlogDocument(id: string): Promise<BlogDocument> {
   return sanityClient.fetch(
-    `*[_type == "blog" && _id == $id][0]{ _id, _createdAt, _updatedAt, publishedAt, title, body }`,
-    { id },
+    `*[_type == $docType && _id == $id][0]{ _id, _createdAt, _updatedAt, publishedAt, title, body }`,
+    { id, docType: DOCUMENT_TYPE },
   )
 }

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -17,11 +17,12 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   function login() {
-    window.location.href = '/.auth/login/aad?post_login_redirect_uri=/'
+    const base = import.meta.env.VITE_AUTH_LOGIN_URL ?? '/.auth/login/aad'
+    window.location.href = `${base}?post_login_redirect_uri=/`
   }
 
   function logout() {
-    window.location.href = '/.auth/logout'
+    window.location.href = import.meta.env.VITE_AUTH_LOGOUT_URL ?? '/.auth/logout'
   }
 
   return { user, loading, isAuthenticated, initialize, login, logout }

--- a/docs/sanity-schema.ts
+++ b/docs/sanity-schema.ts
@@ -1,0 +1,153 @@
+/**
+ * Earnesty — Sanity Studio schema
+ *
+ * Drop this file into your Sanity Studio's `schemaTypes` directory and import
+ * it in `schemaTypes/index.ts`:
+ *
+ *   import { blogType } from './earnesty-schema'
+ *   export const schemaTypes = [blogType]
+ *
+ * Requirements
+ * ────────────
+ * The `code` block type requires the `@sanity/code-input` plugin:
+ *
+ *   npm install @sanity/code-input
+ *
+ * Register it in your `sanity.config.ts`:
+ *
+ *   import { codeInput } from '@sanity/code-input'
+ *   export default defineConfig({ plugins: [codeInput()] })
+ *
+ * Document type name
+ * ──────────────────
+ * The schema below uses the type name `blog`. If you rename it, set the
+ * `VITE_SANITY_DOCUMENT_TYPE` (frontend) and `SANITY_DOCUMENT_TYPE` (API)
+ * environment variables to match.
+ */
+
+import { defineType, defineField } from 'sanity'
+
+export const blogType = defineType({
+  name: 'blog',
+  title: 'Blog post',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: (Rule) => Rule.required(),
+    }),
+
+    defineField({
+      name: 'publishedAt',
+      title: 'Published at',
+      type: 'datetime',
+      // Optional. When absent the app falls back to _createdAt for ordering.
+    }),
+
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [
+        // Standard Portable Text blocks (paragraphs, headings, lists, etc.)
+        {
+          type: 'block',
+          styles: [
+            { title: 'Normal', value: 'normal' },
+            { title: 'Heading 1', value: 'h1' },
+            { title: 'Heading 2', value: 'h2' },
+            { title: 'Heading 3', value: 'h3' },
+            { title: 'Heading 4', value: 'h4' },
+            { title: 'Quote', value: 'blockquote' },
+          ],
+          lists: [
+            { title: 'Bullet', value: 'bullet' },
+            { title: 'Numbered', value: 'number' },
+          ],
+          marks: {
+            decorators: [
+              { title: 'Strong', value: 'strong' },
+              { title: 'Emphasis', value: 'em' },
+              { title: 'Code', value: 'code' },
+            ],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'Link',
+                fields: [
+                  defineField({
+                    name: 'href',
+                    type: 'url',
+                    title: 'URL',
+                    validation: (Rule) =>
+                      Rule.uri({ allowRelative: true, scheme: ['http', 'https', 'mailto'] }),
+                  }),
+                ],
+              },
+            ],
+          },
+        },
+
+        // Inline images
+        {
+          type: 'image',
+          options: { hotspot: true },
+          fields: [
+            defineField({
+              name: 'alt',
+              type: 'string',
+              title: 'Alternative text',
+            }),
+          ],
+        },
+
+        // Code blocks — requires @sanity/code-input plugin
+        {
+          type: 'code',
+          options: {
+            // Languages surfaced in the Studio editor.
+            // The frontend renders any language string via highlight.js.
+            language: 'typescript',
+            languageAlternatives: [
+              { title: 'TypeScript', value: 'typescript' },
+              { title: 'JavaScript', value: 'javascript' },
+              { title: 'CSS', value: 'css' },
+              { title: 'HTML', value: 'html' },
+              { title: 'JSON', value: 'json' },
+              { title: 'Bash', value: 'bash' },
+              { title: 'Python', value: 'python' },
+              { title: 'Go', value: 'go' },
+              { title: 'Rust', value: 'rust' },
+              { title: 'Plain text', value: 'text' },
+            ],
+            withFilename: true,
+          },
+        },
+      ],
+    }),
+  ],
+
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'publishedAt',
+    },
+    prepare({ title, subtitle }) {
+      return {
+        title: title ?? 'Untitled',
+        subtitle: subtitle ? new Date(subtitle as string).toLocaleDateString() : 'Draft',
+      }
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Removes the six hardcoded couplings identified in the decoupling review, making the app reusable by anyone with their own Sanity project and/or a different identity provider.

## Changes

### Configurable Sanity document type
- `VITE_SANITY_DOCUMENT_TYPE` (frontend, default `blog`) and `SANITY_DOCUMENT_TYPE` (API, default `blog`) env vars
- GROQ queries now use `$docType` parameter instead of the string literal `"blog"` in `sanity.ts`, `listDocuments`, and `createDraft`

### Configurable auth provider URLs
- `VITE_AUTH_LOGIN_URL` (default `/.auth/login/aad`), `VITE_AUTH_LOGOUT_URL`, `VITE_AUTH_ME_URL` env vars
- Allows switching to any SWA-supported identity provider (github, google, twitter) without code changes

### Sanity schema definition
- New `docs/sanity-schema.ts` — drop-in Sanity Studio schema for the `blog` document type
- Includes all fields the app reads/writes, `@sanity/code-input` plugin notes, and instructions for renaming the type

### Improved `.env.example`
- Rewritten with labelled sections (Sanity, Auth, Observability, API/server-side)
- Documents all env vars including previously undocumented `VITE_APPLICATIONINSIGHTS_CONNECTION_STRING`

### README improvements
- **Fixes** incorrect `VITE_SANITY_TOKEN` in local dev guide (was telling users to expose their write token in the browser bundle)
- **Adds** self-hosting section: Sanity project setup, minimum local dev config, full env var reference table, auth provider switching guide

### Test updates
- Updated 2 tests that asserted the literal `_type == "blog"` query string to instead verify the parameterized `$docType` + params pattern

## Backwards compatibility

All env vars have defaults matching the original hardcoded values — zero breaking changes for existing deployments.