### PR TITLE
feat: define runtime configuration contract for reusable deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,20 @@ A minimal, focused writing environment built with [Vue 3](https://vuejs.org) and
    ```env
    VITE_SANITY_PROJECT_ID=your_project_id
    VITE_SANITY_DATASET=dev
-   VITE_SANITY_TOKEN=your_sanity_token
+   VITE_SANITY_DOCUMENT_TYPE=blog
+   VITE_SANITY_TITLE_FIELD=title
+   VITE_SANITY_BODY_FIELD=body
+   VITE_SANITY_SLUG_FIELD=slug
+   VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
+   VITE_SANITY_DRAFT_PREFIX=drafts.
+   VITE_AUTH_LOGIN_PATH=/.auth/login/aad
+   VITE_AUTH_LOGOUT_PATH=/.auth/logout
+   VITE_AUTH_POST_LOGIN_REDIRECT_PARAM=post_login_redirect_uri
+   VITE_APP_NAME=Earnesty
+   VITE_APP_INTRO_TITLE=Earnesty is your space for focused writing
    ```
+
+   `SANITY_TOKEN` remains server-side only and must not be added as a `VITE_` variable.
 
 3. **Start the dev server**
 
@@ -47,6 +59,46 @@ A minimal, focused writing environment built with [Vue 3](https://vuejs.org) and
    ```
 
    This runs ESLint and type-check automatically before every commit.
+
+## Runtime configuration contract
+
+The app and API expose a typed runtime configuration contract so deployments can customize branding, schema mapping, and auth endpoints without code changes.
+
+### Frontend (`VITE_*`)
+
+| Variable | Required | Default |
+|---|---|---|
+| `VITE_SANITY_PROJECT_ID` | Yes | — |
+| `VITE_SANITY_DATASET` | No | `production` |
+| `VITE_SANITY_DOCUMENT_TYPE` | No | `blog` |
+| `VITE_SANITY_TITLE_FIELD` | No | `title` |
+| `VITE_SANITY_BODY_FIELD` | No | `body` |
+| `VITE_SANITY_SLUG_FIELD` | No | `slug` |
+| `VITE_SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
+| `VITE_SANITY_DRAFT_PREFIX` | No | `drafts.` |
+| `VITE_AUTH_LOGIN_PATH` | No | `/.auth/login/aad` |
+| `VITE_AUTH_LOGOUT_PATH` | No | `/.auth/logout` |
+| `VITE_AUTH_POST_LOGIN_REDIRECT_PARAM` | No | `post_login_redirect_uri` |
+| `VITE_APP_NAME` | No | `Earnesty` |
+| `VITE_APP_INTRO_TITLE` | No | `${VITE_APP_NAME} is your space for focused writing` |
+| `VITE_APPLICATIONINSIGHTS_CONNECTION_STRING` | No | unset |
+
+### API / SWA app settings
+
+| Variable | Required | Default |
+|---|---|---|
+| `SANITY_PROJECT_ID` | Yes | — |
+| `SANITY_TOKEN` | Yes | — |
+| `SANITY_DATASET` | No | `production` |
+| `SANITY_API_VERSION` | No | `2024-01-01` |
+| `SANITY_DOCUMENT_TYPE` | No | `blog` |
+| `SANITY_TITLE_FIELD` | No | `title` |
+| `SANITY_BODY_FIELD` | No | `body` |
+| `SANITY_SLUG_FIELD` | No | `slug` |
+| `SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
+| `SANITY_DRAFT_PREFIX` | No | `drafts.` |
+
+Validation is fail-fast: missing required variables or invalid values (for example malformed field names or draft prefix without a trailing dot) throw explicit startup/runtime errors.
 
 ## Building for production
 
@@ -197,4 +249,3 @@ On the app registration, add a federated credential to trust GitHub Actions toke
    - **Entity type:** `Environment`
    - **GitHub environment name:** `production`
 4. Click **Add**
-

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,6 +1,20 @@
 # Sanity.io project configuration (read-only, public)
 VITE_SANITY_PROJECT_ID=your_project_id
 VITE_SANITY_DATASET=dev
+# Optional Sanity schema mapping
+VITE_SANITY_DOCUMENT_TYPE=blog
+VITE_SANITY_TITLE_FIELD=title
+VITE_SANITY_BODY_FIELD=body
+VITE_SANITY_SLUG_FIELD=slug
+VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
+VITE_SANITY_DRAFT_PREFIX=drafts.
+# Optional auth route mapping
+VITE_AUTH_LOGIN_PATH=/.auth/login/aad
+VITE_AUTH_LOGOUT_PATH=/.auth/logout
+VITE_AUTH_POST_LOGIN_REDIRECT_PARAM=post_login_redirect_uri
+# Optional app branding defaults
+VITE_APP_NAME=Earnesty
+VITE_APP_INTRO_TITLE=Earnesty is your space for focused writing
 # Write operations are handled server-side by the SWA API backend.
 # The Sanity API token is configured as an SWA app setting (SANITY_TOKEN),
 # not as a VITE_ env var — it must never be exposed to the browser.

--- a/app/api/src/__tests__/shared.test.ts
+++ b/app/api/src/__tests__/shared.test.ts
@@ -35,6 +35,7 @@ describe('getSanityClient', () => {
     savedEnv['SANITY_PROJECT_ID'] = process.env['SANITY_PROJECT_ID']
     savedEnv['SANITY_TOKEN'] = process.env['SANITY_TOKEN']
     savedEnv['SANITY_DATASET'] = process.env['SANITY_DATASET']
+    savedEnv['NODE_ENV'] = process.env['NODE_ENV']
     vi.resetModules()
   })
 
@@ -46,6 +47,7 @@ describe('getSanityClient', () => {
   })
 
   it('throws when SANITY_PROJECT_ID is missing', async () => {
+    process.env['NODE_ENV'] = 'production'
     delete process.env['SANITY_PROJECT_ID']
     process.env['SANITY_TOKEN'] = 'test-token'
     const { getSanityClient } = await import('../shared.js')
@@ -53,6 +55,7 @@ describe('getSanityClient', () => {
   })
 
   it('throws when SANITY_TOKEN is missing', async () => {
+    process.env['NODE_ENV'] = 'production'
     process.env['SANITY_PROJECT_ID'] = 'test-project'
     delete process.env['SANITY_TOKEN']
     const { getSanityClient } = await import('../shared.js')
@@ -60,6 +63,7 @@ describe('getSanityClient', () => {
   })
 
   it('throws listing both variables when both are missing', async () => {
+    process.env['NODE_ENV'] = 'production'
     delete process.env['SANITY_PROJECT_ID']
     delete process.env['SANITY_TOKEN']
     const { getSanityClient } = await import('../shared.js')

--- a/app/api/src/config/__tests__/runtime.test.ts
+++ b/app/api/src/config/__tests__/runtime.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { clearApiRuntimeConfigCache, getApiRuntimeConfig } from '../runtime.js'
+
+describe('getApiRuntimeConfig', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env['NODE_ENV'] = 'test'
+    clearApiRuntimeConfigCache()
+  })
+
+  it('throws when required vars are missing', () => {
+    process.env['NODE_ENV'] = 'production'
+    delete process.env['SANITY_PROJECT_ID']
+    delete process.env['SANITY_TOKEN']
+
+    expect(() => getApiRuntimeConfig()).toThrow('Missing required environment variable(s)')
+  })
+
+  it('uses defaults for optional values', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+
+    const config = getApiRuntimeConfig()
+    expect(config.sanity.dataset).toBe('production')
+    expect(config.content.documentType).toBe('blog')
+    expect(config.content.draftPrefix).toBe('drafts.')
+  })
+
+  it('throws when SANITY_DRAFT_PREFIX does not end with a dot', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+    process.env['SANITY_DRAFT_PREFIX'] = 'drafts'
+
+    expect(() => getApiRuntimeConfig()).toThrow('SANITY_DRAFT_PREFIX must end with "."')
+  })
+
+  it('accepts schema overrides', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+    process.env['SANITY_DOCUMENT_TYPE'] = 'article'
+    process.env['SANITY_TITLE_FIELD'] = 'headline'
+
+    const config = getApiRuntimeConfig()
+    expect(config.content.documentType).toBe('article')
+    expect(config.content.titleField).toBe('headline')
+  })
+})

--- a/app/api/src/config/runtime.ts
+++ b/app/api/src/config/runtime.ts
@@ -1,0 +1,86 @@
+export interface ApiRuntimeConfig {
+  sanity: {
+    projectId: string
+    token: string
+    dataset: string
+    apiVersion: string
+  }
+  content: {
+    documentType: string
+    draftPrefix: string
+    titleField: string
+    bodyField: string
+    slugField: string
+    publishedAtField: string
+  }
+}
+
+let cachedConfig: ApiRuntimeConfig | null = null
+
+function envString(value: string | undefined): string | undefined {
+  return value?.trim() || undefined
+}
+
+function readFieldName(value: string | undefined, fallback: string, key: string): string {
+  const field = envString(value) ?? fallback
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(field)) {
+    throw new Error(`Invalid runtime configuration: ${key} must match /^[A-Za-z_][A-Za-z0-9_]*$/`)
+  }
+  return field
+}
+
+export function getApiRuntimeConfig(): ApiRuntimeConfig {
+  if (cachedConfig) return cachedConfig
+
+  const projectId = envString(process.env['SANITY_PROJECT_ID'])
+  const token = envString(process.env['SANITY_TOKEN'])
+  const missing = [
+    !projectId && 'SANITY_PROJECT_ID',
+    !token && 'SANITY_TOKEN',
+  ].filter(Boolean).join(', ')
+  const isTest = process.env['NODE_ENV'] === 'test'
+  if (missing && !isTest) {
+    throw new Error(`Missing required environment variable(s): ${missing}`)
+  }
+
+  const draftPrefix = envString(process.env['SANITY_DRAFT_PREFIX']) ?? 'drafts.'
+  if (!draftPrefix.endsWith('.')) {
+    throw new Error('Invalid runtime configuration: SANITY_DRAFT_PREFIX must end with "."')
+  }
+
+  cachedConfig = {
+    sanity: {
+      projectId: projectId ?? 'unset',
+      token: token ?? 'unset',
+      dataset: envString(process.env['SANITY_DATASET']) ?? 'production',
+      apiVersion: envString(process.env['SANITY_API_VERSION']) ?? '2024-01-01',
+    },
+    content: {
+      documentType: readFieldName(process.env['SANITY_DOCUMENT_TYPE'], 'blog', 'SANITY_DOCUMENT_TYPE'),
+      draftPrefix,
+      titleField: readFieldName(process.env['SANITY_TITLE_FIELD'], 'title', 'SANITY_TITLE_FIELD'),
+      bodyField: readFieldName(process.env['SANITY_BODY_FIELD'], 'body', 'SANITY_BODY_FIELD'),
+      slugField: readFieldName(process.env['SANITY_SLUG_FIELD'], 'slug', 'SANITY_SLUG_FIELD'),
+      publishedAtField: readFieldName(
+        process.env['SANITY_PUBLISHED_AT_FIELD'],
+        'publishedAt',
+        'SANITY_PUBLISHED_AT_FIELD',
+      ),
+    },
+  }
+
+  return cachedConfig
+}
+
+export function clearApiRuntimeConfigCache(): void {
+  cachedConfig = null
+}
+
+export function isDraftDocumentId(id: string): boolean {
+  return id.startsWith(getApiRuntimeConfig().content.draftPrefix)
+}
+
+export function toPublishedDocumentId(draftId: string): string {
+  const prefix = getApiRuntimeConfig().content.draftPrefix
+  return draftId.slice(prefix.length)
+}

--- a/app/api/src/functions/createDraft.ts
+++ b/app/api/src/functions/createDraft.ts
@@ -4,6 +4,7 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getApiRuntimeConfig } from '../config/runtime.js'
 
 app.http('createDraft', {
   methods: ['POST'],
@@ -34,13 +35,16 @@ app.http('createDraft', {
     }
 
     try {
-      const id = `drafts.${crypto.randomUUID()}`
-      const doc = await getSanityClient().create({
+      const config = getApiRuntimeConfig()
+      const client = getSanityClient()
+      const id = `${config.content.draftPrefix}${crypto.randomUUID()}`
+      const createPayload: Record<string, unknown> = {
         _id: id,
-        _type: 'blog',
-        title: body.title.trim(),
-        slug: { _type: 'slug', current: body.slug.trim() },
-      })
+        _type: config.content.documentType,
+        [config.content.titleField]: body.title.trim(),
+        [config.content.slugField]: { _type: 'slug', current: body.slug.trim() },
+      }
+      const doc = await client.create(createPayload as Parameters<typeof client.create>[0])
       return { status: 201, jsonBody: doc }
     } catch (err) {
       console.error('[createDraft]', err)

--- a/app/api/src/functions/listDocuments.ts
+++ b/app/api/src/functions/listDocuments.ts
@@ -4,6 +4,7 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getApiRuntimeConfig } from '../config/runtime.js'
 
 app.http('listDocuments', {
   methods: ['GET'],
@@ -20,14 +21,15 @@ app.http('listDocuments', {
     }
 
     try {
+      const config = getApiRuntimeConfig()
       const docs = await getSanityClient().fetch(
-        `*[_type == "blog"] | order(coalesce(publishedAt, _createdAt) desc) {
+        `*[_type == "${config.content.documentType}"] | order(coalesce(${config.content.publishedAtField}, _createdAt) desc) {
           _id,
           _createdAt,
           _updatedAt,
-          publishedAt,
-          title,
-          "body": body[_type == "block"][0..10]
+          "publishedAt": ${config.content.publishedAtField},
+          "title": ${config.content.titleField},
+          "body": ${config.content.bodyField}[_type == "block"][0..10]
         }`,
       )
       return { status: 200, jsonBody: docs }

--- a/app/api/src/functions/publishDocument.ts
+++ b/app/api/src/functions/publishDocument.ts
@@ -4,6 +4,7 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { isDraftDocumentId, toPublishedDocumentId } from '../config/runtime.js'
 
 app.http('publishDocument', {
   methods: ['POST'],
@@ -24,7 +25,7 @@ app.http('publishDocument', {
       return { status: 400, jsonBody: { error: 'Missing document ID' } }
     }
 
-    if (!id.startsWith('drafts.')) {
+    if (!isDraftDocumentId(id)) {
       return { status: 400, jsonBody: { error: 'Document is not a draft' } }
     }
 
@@ -34,7 +35,7 @@ app.http('publishDocument', {
         return { status: 404, jsonBody: { error: 'Draft not found' } }
       }
 
-      const publishedId = id.slice('drafts.'.length)
+      const publishedId = toPublishedDocumentId(id)
 
       // Copy the draft content to the published document and delete the draft
       // in a single transaction so Sanity never sees an inconsistent state.

--- a/app/api/src/functions/saveDocument.ts
+++ b/app/api/src/functions/saveDocument.ts
@@ -4,6 +4,7 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getApiRuntimeConfig } from '../config/runtime.js'
 
 app.http('saveDocument', {
   methods: ['PATCH'],
@@ -24,7 +25,12 @@ app.http('saveDocument', {
       return { status: 400, jsonBody: { error: 'Missing document ID' } }
     }
 
-    const DRAFT_ID_RE = /^drafts\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    const draftPrefix = getApiRuntimeConfig().content.draftPrefix
+    const escapedPrefix = draftPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const DRAFT_ID_RE = new RegExp(
+      `^${escapedPrefix}[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+      'i',
+    )
     if (!DRAFT_ID_RE.test(id)) {
       return { status: 400, jsonBody: { error: 'Invalid document ID' } }
     }
@@ -58,12 +64,13 @@ app.http('saveDocument', {
     }
 
     try {
+      const config = getApiRuntimeConfig()
       const fields: Record<string, unknown> = {}
       if (Array.isArray(body.blocks)) {
-        fields['body'] = body.blocks
+        fields[config.content.bodyField] = body.blocks
       }
       if (typeof body.title === 'string') {
-        fields['title'] = body.title
+        fields[config.content.titleField] = body.title
       }
       await getSanityClient().patch(id).set(fields).commit()
       return { status: 204 }

--- a/app/api/src/shared.ts
+++ b/app/api/src/shared.ts
@@ -1,4 +1,5 @@
 import { createClient, type SanityClient } from '@sanity/client'
+import { getApiRuntimeConfig } from './config/runtime.js'
 
 let _client: SanityClient | null = null
 
@@ -8,22 +9,12 @@ let _client: SanityClient | null = null
  *  are not yet available at cold-start time. */
 export function getSanityClient(): SanityClient {
   if (!_client) {
-    const projectId = process.env['SANITY_PROJECT_ID']
-    const token = process.env['SANITY_TOKEN']
-    if (!projectId || !token) {
-      const missing = [
-        !projectId && 'SANITY_PROJECT_ID',
-        !token && 'SANITY_TOKEN',
-      ].filter(Boolean).join(', ')
-      throw new Error(
-        `Missing required environment variable(s): ${missing}`,
-      )
-    }
+    const config = getApiRuntimeConfig()
     _client = createClient({
-      projectId,
-      dataset: process.env['SANITY_DATASET'] ?? 'production',
-      apiVersion: '2024-01-01',
-      token,
+      projectId: config.sanity.projectId,
+      dataset: config.sanity.dataset,
+      apiVersion: config.sanity.apiVersion,
+      token: config.sanity.token,
       useCdn: false,
     })
   }

--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -1,1 +1,27 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME?: string
+  readonly VITE_APP_INTRO_TITLE?: string
+  readonly VITE_APP_INTRO_LEAD?: string
+  readonly VITE_APP_INTRO_HINT?: string
+  readonly VITE_APP_ABOUT_SUMMARY?: string
+  readonly VITE_SANITY_PROJECT_ID?: string
+  readonly VITE_SANITY_DATASET?: string
+  readonly VITE_SANITY_API_VERSION?: string
+  readonly VITE_SANITY_DOCUMENT_TYPE?: string
+  readonly VITE_SANITY_TITLE_FIELD?: string
+  readonly VITE_SANITY_BODY_FIELD?: string
+  readonly VITE_SANITY_SLUG_FIELD?: string
+  readonly VITE_SANITY_PUBLISHED_AT_FIELD?: string
+  readonly VITE_SANITY_DRAFT_PREFIX?: string
+  readonly VITE_AUTH_LOGIN_PATH?: string
+  readonly VITE_AUTH_LOGOUT_PATH?: string
+  readonly VITE_AUTH_POST_LOGIN_REDIRECT_PARAM?: string
+  readonly VITE_APPLICATIONINSIGHTS_CONNECTION_STRING?: string
+  readonly VITE_USE_PROXY?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -11,6 +11,7 @@ import { useAuthStore } from './stores/auth'
 import { fetchBlogDocument, portableTextToHtml, type BlogDocument } from './services/sanity'
 import { apiPublishDocument, apiSaveDocument } from './services/api'
 import { trackException, trackEvent } from './services/appInsights'
+import { runtimeConfig } from './config/runtime'
 
 const showOpen = ref(false)
 const showHelp = ref(false)
@@ -18,6 +19,7 @@ const showSettings = ref(false)
 const showPublishModal = ref(false)
 const editorStore = useEditorStore()
 const auth = useAuthStore()
+const draftPrefix = runtimeConfig.content.draftPrefix
 
 async function onDocumentSelected(doc: BlogDocument) {
   const full = await fetchBlogDocument(doc._id)
@@ -38,13 +40,13 @@ function escapeHtml(str: string): string {
 const canPublish = computed(() =>
   auth.isAuthenticated
   && !!editorStore.activeDocument
-  && editorStore.activeDocument._id.startsWith('drafts.')
+  && editorStore.activeDocument._id.startsWith(draftPrefix)
   && editorStore.publishStatus !== 'publishing',
 )
 
 const isDraft = computed(() =>
   !!editorStore.activeDocument
-  && editorStore.activeDocument._id.startsWith('drafts.'),
+  && editorStore.activeDocument._id.startsWith(draftPrefix),
 )
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
@@ -173,4 +175,3 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
 </template>
 
 <style scoped></style>
-

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -4,6 +4,7 @@ import AppLogo from './AppLogo.vue'
 import UserModal from './UserModal.vue'
 import type { SaveStatus, PublishStatus } from '../stores/editor'
 import type { SwaUser } from '../stores/auth'
+import { runtimeConfig } from '../config/runtime'
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
 const mod = isMac ? '⌘' : 'Ctrl+'
@@ -86,7 +87,7 @@ function onLeave() {
       <div class="menubar__left">
         <span class="menubar__brand">
           <AppLogo :size="16" />
-          Earnesty
+          {{ runtimeConfig.app.name }}
         </span>
         <span
           v-if="documentTitle"

--- a/app/src/components/HelpModal.vue
+++ b/app/src/components/HelpModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import BaseModal from './BaseModal.vue'
+import { runtimeConfig } from '../config/runtime'
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
 const mod = isMac ? '⌘' : 'Ctrl+'
@@ -23,7 +24,7 @@ const shortcuts = [
     @close="$emit('close')"
   >
     <p class="intro">
-      Earnesty is a distraction-free writing environment. Click anywhere on the page and start
+      {{ runtimeConfig.app.name }} is a distraction-free writing environment. Click anywhere on the page and start
       typing. Your words are the only thing that matters.
     </p>
     <p class="intro">

--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import BaseModal from './BaseModal.vue'
 import { useBlogDocuments } from '../composables/useBlogDocuments'
 import { extractPreview, type BlogDocument } from '../services/sanity'
+import { runtimeConfig } from '../config/runtime'
 
 const emit = defineEmits<{
   close: []
@@ -10,6 +11,7 @@ const emit = defineEmits<{
 }>()
 
 const { documents, loading, error } = useBlogDocuments()
+const draftPrefix = runtimeConfig.content.draftPrefix
 
 // ── Search & sort ─────────────────────────────────────────────────────────────
 type SortKey = 'newest' | 'oldest' | 'title-asc' | 'title-desc'
@@ -32,8 +34,8 @@ const resolvedDocs = computed<{ doc: BlogDocument; status: DocStatus }[]>(() => 
   const map = new Map<string, { draft?: BlogDocument; published?: BlogDocument }>()
 
   for (const doc of documents.value) {
-    const isDraft = doc._id.startsWith('drafts.')
-    const baseId = isDraft ? doc._id.slice('drafts.'.length) : doc._id
+    const isDraft = doc._id.startsWith(draftPrefix)
+    const baseId = isDraft ? doc._id.slice(draftPrefix.length) : doc._id
     const entry = map.get(baseId) ?? {}
     if (isDraft) entry.draft = doc
     else entry.published = doc

--- a/app/src/config/__tests__/runtime.test.ts
+++ b/app/src/config/__tests__/runtime.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { createRuntimeConfig } from '../runtime.js'
+
+function makeEnv(overrides: Record<string, string | undefined> = {}): ImportMetaEnv {
+  return {
+    BASE_URL: '/',
+    DEV: false,
+    PROD: true,
+    MODE: 'production',
+    SSR: false,
+    VITE_SANITY_PROJECT_ID: 'test-project',
+    ...overrides,
+  }
+}
+
+describe('createRuntimeConfig', () => {
+  it('applies defaults for optional values', () => {
+    const config = createRuntimeConfig(makeEnv())
+
+    expect(config.content.documentType).toBe('blog')
+    expect(config.content.draftPrefix).toBe('drafts.')
+    expect(config.auth.loginPath).toBe('/.auth/login/aad')
+    expect(config.app.name).toBe('Earnesty')
+  })
+
+  it('throws when VITE_SANITY_PROJECT_ID is missing outside test mode', () => {
+    expect(() => createRuntimeConfig(makeEnv({ VITE_SANITY_PROJECT_ID: undefined }))).toThrow(
+      'VITE_SANITY_PROJECT_ID is required',
+    )
+  })
+
+  it('allows missing VITE_SANITY_PROJECT_ID in test mode', () => {
+    const config = createRuntimeConfig(makeEnv({ MODE: 'test', VITE_SANITY_PROJECT_ID: undefined }))
+    expect(config.sanity.projectId).toBe('unset')
+  })
+
+  it('throws when the draft prefix does not end with a dot', () => {
+    expect(() => createRuntimeConfig(makeEnv({ VITE_SANITY_DRAFT_PREFIX: 'drafts' }))).toThrow(
+      'VITE_SANITY_DRAFT_PREFIX must end with "."',
+    )
+  })
+
+  it('uses custom schema mapping when provided', () => {
+    const config = createRuntimeConfig(
+      makeEnv({
+        VITE_SANITY_DOCUMENT_TYPE: 'article',
+        VITE_SANITY_TITLE_FIELD: 'headline',
+        VITE_SANITY_BODY_FIELD: 'content',
+        VITE_SANITY_SLUG_FIELD: 'path',
+        VITE_SANITY_PUBLISHED_AT_FIELD: 'publishedOn',
+      }),
+    )
+
+    expect(config.content).toMatchObject({
+      documentType: 'article',
+      titleField: 'headline',
+      bodyField: 'content',
+      slugField: 'path',
+      publishedAtField: 'publishedOn',
+    })
+  })
+})

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -1,0 +1,135 @@
+export interface FrontendRuntimeConfig {
+  app: {
+    name: string
+    introTitle: string
+    introLead: string
+    introHint: string
+    aboutSummary: string
+  }
+  auth: {
+    loginPath: string
+    logoutPath: string
+    postLoginRedirectParam: string
+  }
+  content: {
+    documentType: string
+    draftPrefix: string
+    titleField: string
+    bodyField: string
+    slugField: string
+    publishedAtField: string
+  }
+  sanity: {
+    projectId: string
+    dataset: string
+    apiVersion: string
+    useProxy: boolean
+  }
+  telemetry: {
+    applicationInsightsConnectionString?: string
+  }
+}
+
+function envString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function readPath(value: string | undefined, fallback: string, key: string): string {
+  const path = value ?? fallback
+  if (!path.startsWith('/')) {
+    throw new Error(`Invalid runtime configuration: ${key} must start with "/"`)
+  }
+  return path
+}
+
+function readFieldName(value: string | undefined, fallback: string, key: string): string {
+  const field = value ?? fallback
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(field)) {
+    throw new Error(
+      `Invalid runtime configuration: ${key} must match /^[A-Za-z_][A-Za-z0-9_]*$/`,
+    )
+  }
+  return field
+}
+
+export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
+  const appName = envString(env.VITE_APP_NAME) ?? 'Earnesty'
+  const introTitle = envString(env.VITE_APP_INTRO_TITLE) ?? `${appName} is your space for focused writing`
+  const introLead = envString(env.VITE_APP_INTRO_LEAD)
+    ?? 'No distractions. No formatting toolbars. Just you and the blank page. All vibes. No QA.'
+  const introHint = envString(env.VITE_APP_INTRO_HINT)
+    ?? 'Select any part of this text and start typing to replace it — or click anywhere to place your cursor and begin.'
+  const aboutSummary = envString(env.VITE_APP_ABOUT_SUMMARY) ?? 'A minimal, focused writing environment.'
+
+  const mode = env.MODE
+  const isTest = mode === 'test'
+  const projectId = envString(env.VITE_SANITY_PROJECT_ID) ?? (isTest ? 'unset' : undefined)
+  if (!projectId) {
+    throw new Error('Invalid runtime configuration: VITE_SANITY_PROJECT_ID is required')
+  }
+
+  const draftPrefix = envString(env.VITE_SANITY_DRAFT_PREFIX) ?? 'drafts.'
+  if (!draftPrefix.endsWith('.')) {
+    throw new Error('Invalid runtime configuration: VITE_SANITY_DRAFT_PREFIX must end with "."')
+  }
+
+  return {
+    app: {
+      name: appName,
+      introTitle,
+      introLead,
+      introHint,
+      aboutSummary,
+    },
+    auth: {
+      loginPath: readPath(envString(env.VITE_AUTH_LOGIN_PATH), '/.auth/login/aad', 'VITE_AUTH_LOGIN_PATH'),
+      logoutPath: readPath(envString(env.VITE_AUTH_LOGOUT_PATH), '/.auth/logout', 'VITE_AUTH_LOGOUT_PATH'),
+      postLoginRedirectParam: envString(env.VITE_AUTH_POST_LOGIN_REDIRECT_PARAM) ?? 'post_login_redirect_uri',
+    },
+    content: {
+      documentType: readFieldName(
+        envString(env.VITE_SANITY_DOCUMENT_TYPE),
+        'blog',
+        'VITE_SANITY_DOCUMENT_TYPE',
+      ),
+      draftPrefix,
+      titleField: readFieldName(envString(env.VITE_SANITY_TITLE_FIELD), 'title', 'VITE_SANITY_TITLE_FIELD'),
+      bodyField: readFieldName(envString(env.VITE_SANITY_BODY_FIELD), 'body', 'VITE_SANITY_BODY_FIELD'),
+      slugField: readFieldName(envString(env.VITE_SANITY_SLUG_FIELD), 'slug', 'VITE_SANITY_SLUG_FIELD'),
+      publishedAtField: readFieldName(
+        envString(env.VITE_SANITY_PUBLISHED_AT_FIELD),
+        'publishedAt',
+        'VITE_SANITY_PUBLISHED_AT_FIELD',
+      ),
+    },
+    sanity: {
+      projectId,
+      dataset: envString(env.VITE_SANITY_DATASET) ?? 'production',
+      apiVersion: envString(env.VITE_SANITY_API_VERSION) ?? '2024-01-01',
+      useProxy: env.VITE_USE_PROXY === 'true',
+    },
+    telemetry: {
+      applicationInsightsConnectionString: envString(env.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING),
+    },
+  }
+}
+
+export const runtimeConfig = createRuntimeConfig(import.meta.env)
+
+export function isDraftDocumentId(id: string): boolean {
+  return id.startsWith(runtimeConfig.content.draftPrefix)
+}
+
+export function toPublishedDocumentId(draftId: string): string {
+  const prefix = runtimeConfig.content.draftPrefix
+  if (!draftId.startsWith(prefix)) return draftId
+  return draftId.slice(prefix.length)
+}
+
+export function draftDocumentIdPattern(): RegExp {
+  return new RegExp(`^${escapeRegex(runtimeConfig.content.draftPrefix)}.+$`)
+}

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,4 +1,6 @@
+import { runtimeConfig } from './config/runtime'
+
 /** Default placeholder content shown in a fresh, unsaved editor. */
-export const INTRO_HTML = `<h1 data-type="title">Earnesty is your space for focused writing</h1>
-<p>No distractions. No formatting toolbars. Just you and the blank page. All vibes. No QA.</p>
-<p>Select any part of this text and start typing to replace it — or click anywhere to place your cursor and begin.</p>`
+export const INTRO_HTML = `<h1 data-type="title">${runtimeConfig.app.introTitle}</h1>
+<p>${runtimeConfig.app.introLead}</p>
+<p>${runtimeConfig.app.introHint}</p>`

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,5 +1,6 @@
 import type { SanityBodyBlock, BlogDocument } from './sanity'
 import { trackException } from './appInsights'
+import { runtimeConfig } from '../config/runtime'
 
 export interface ImageAsset {
   assetRef: string
@@ -8,7 +9,8 @@ export interface ImageAsset {
   height: number | null
 }
 
-const LOGIN_PATH = '/.auth/login/aad'
+const LOGIN_PATH = runtimeConfig.auth.loginPath
+const POST_LOGIN_REDIRECT_PARAM = runtimeConfig.auth.postLoginRedirectParam
 const REDIRECT_COOLDOWN_MS = 10_000
 const REDIRECT_TS_KEY = '__auth_redirect_ts'
 
@@ -25,7 +27,7 @@ function redirectToLogin(): never {
   if (!redirectUri.startsWith('/') || redirectUri.startsWith('//')) {
     redirectUri = '/'
   }
-  window.location.href = `${LOGIN_PATH}?post_login_redirect_uri=${encodeURIComponent(redirectUri)}`
+  window.location.href = `${LOGIN_PATH}?${POST_LOGIN_REDIRECT_PARAM}=${encodeURIComponent(redirectUri)}`
   throw new Error('Not authenticated')
 }
 

--- a/app/src/services/appInsights.ts
+++ b/app/src/services/appInsights.ts
@@ -1,8 +1,9 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
+import { runtimeConfig } from '../config/runtime'
 
 let appInsights: ApplicationInsights | null = null
 
-const connectionString = import.meta.env.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING as string | undefined
+const connectionString = runtimeConfig.telemetry.applicationInsightsConnectionString
 
 export function loadAppInsights(): void {
   if (!connectionString) return

--- a/app/src/services/sanity.ts
+++ b/app/src/services/sanity.ts
@@ -1,23 +1,19 @@
 import { createClient } from '@sanity/client'
+import { runtimeConfig } from '../config/runtime'
 
-// In development the Vite server proxies /v2024-01-01/… to the real Sanity
-// API, avoiding the CORS restriction on localhost. In production and in tests
-// the client talks directly to the Sanity API (bypassing CDN to avoid stale
-// content). VITE_USE_PROXY is set in .env.development and must NOT be set in
-// test configs so that integration tests hit the real Sanity API directly.
-const devProxyConfig =
-  import.meta.env.VITE_USE_PROXY === 'true'
-    ? { apiHost: window.location.origin, useProjectHostname: false, useCdn: false }
-    : { useCdn: false }
+const contentConfig = runtimeConfig.content
+
+// In development the Vite server proxies Sanity API paths through localhost to
+// avoid CORS restrictions. In production and in tests the client talks directly
+// to Sanity (bypassing CDN to avoid stale content).
+const devProxyConfig = runtimeConfig.sanity.useProxy
+  ? { apiHost: window.location.origin, useProjectHostname: false, useCdn: false }
+  : { useCdn: false }
 
 export const sanityClient = createClient({
-  // Fall back to a placeholder so the module doesn't throw at import time when
-  // VITE_SANITY_PROJECT_ID is absent (e.g. CI jobs without dev-environment
-  // secrets). Integration tests guard themselves with describe.skipIf, but the
-  // skip check only runs after the import succeeds.
-  projectId: import.meta.env.VITE_SANITY_PROJECT_ID ?? 'unset',
-  dataset: import.meta.env.VITE_SANITY_DATASET ?? 'production',
-  apiVersion: '2024-01-01',
+  projectId: runtimeConfig.sanity.projectId,
+  dataset: runtimeConfig.sanity.dataset,
+  apiVersion: runtimeConfig.sanity.apiVersion,
   ...devProxyConfig,
 })
 
@@ -74,8 +70,8 @@ export interface BlogDocument {
 
 /** Converts a Sanity image asset ref to a CDN URL. */
 export function buildSanityImageUrl(ref: string): string {
-  const projectId = import.meta.env.VITE_SANITY_PROJECT_ID
-  const dataset = import.meta.env.VITE_SANITY_DATASET ?? 'production'
+  const projectId = runtimeConfig.sanity.projectId
+  const dataset = runtimeConfig.sanity.dataset
   // ref format: "image-{id}-{WxH}-{ext}"  →  "{id}-{WxH}.{ext}"
   const filename = ref.replace(/^image-/, '').replace(/-([a-z0-9]+)$/i, '.$1')
   return `https://cdn.sanity.io/images/${projectId}/${dataset}/${filename}`
@@ -327,13 +323,13 @@ function key() {
 /** Fetch list of blog documents (title + enough body blocks for 50-word preview). */
 export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
   return sanityClient.fetch(`
-    *[_type == "blog"] | order(coalesce(publishedAt, _createdAt) desc) {
+    *[_type == "${contentConfig.documentType}"] | order(coalesce(${contentConfig.publishedAtField}, _createdAt) desc) {
       _id,
       _createdAt,
       _updatedAt,
-      publishedAt,
-      title,
-      "body": body[_type == "block"][0..10]
+      "publishedAt": ${contentConfig.publishedAtField},
+      "title": ${contentConfig.titleField},
+      "body": ${contentConfig.bodyField}[_type == "block"][0..10]
     }
   `)
 }
@@ -341,7 +337,14 @@ export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
 /** Fetch the full body of a single document for editing. */
 export async function fetchBlogDocument(id: string): Promise<BlogDocument> {
   return sanityClient.fetch(
-    `*[_type == "blog" && _id == $id][0]{ _id, _createdAt, _updatedAt, publishedAt, title, body }`,
+    `*[_type == "${contentConfig.documentType}" && _id == $id][0]{
+      _id,
+      _createdAt,
+      _updatedAt,
+      "publishedAt": ${contentConfig.publishedAtField},
+      "title": ${contentConfig.titleField},
+      "body": ${contentConfig.bodyField}
+    }`,
     { id },
   )
 }

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { apiGetUser, type SwaUser } from '../services/api'
+import { runtimeConfig } from '../config/runtime'
 
 export type { SwaUser }
 
@@ -17,11 +18,12 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   function login() {
-    window.location.href = '/.auth/login/aad?post_login_redirect_uri=/'
+    window.location.href =
+      `${runtimeConfig.auth.loginPath}?${runtimeConfig.auth.postLoginRedirectParam}=/`
   }
 
   function logout() {
-    window.location.href = '/.auth/logout'
+    window.location.href = runtimeConfig.auth.logoutPath
   }
 
   return { user, loading, isAuthenticated, initialize, login, logout }

--- a/app/src/views/AboutView.vue
+++ b/app/src/views/AboutView.vue
@@ -1,9 +1,11 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { runtimeConfig } from '../config/runtime'
+</script>
 
 <template>
   <main class="about">
-    <h1>Earnesty</h1>
-    <p>A minimal, focused writing environment.</p>
+    <h1>{{ runtimeConfig.app.name }}</h1>
+    <p>{{ runtimeConfig.app.aboutSummary }}</p>
   </main>
 </template>
 

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -13,6 +13,7 @@ import { tiptapJsonToPortableText, type TiptapNode } from '../services/sanity'
 import { apiSaveDocument, apiCreateDraft, apiUploadImage, type ImageAsset } from '../services/api'
 import { trackException, trackEvent } from '../services/appInsights'
 import { INTRO_HTML } from '../constants'
+import { runtimeConfig } from '../config/runtime'
 import { TitleNode } from '../extensions/TitleNode'
 import { TitleDocument } from '../extensions/TitleDocument'
 import { BlockInserter, BLOCK_INSERTER_EVENT } from '../extensions/BlockInserter'
@@ -59,7 +60,7 @@ let latestJson: TiptapNode | null = null
 let creatingDraft = false
 let currentSavePromise: Promise<void> | null = null
 
-const INTRO_TITLE = 'Earnesty is your space for focused writing'
+const INTRO_TITLE = runtimeConfig.app.introTitle
 
 // Register flushSave so App.vue can drain pending saves before publish
 editorStore.flushSave = async () => {
@@ -418,7 +419,7 @@ watch(
           :size="120"
           class="intro-lockup__logo"
         />
-        <span class="intro-lockup__name">Earnesty</span>
+        <span class="intro-lockup__name">{{ runtimeConfig.app.name }}</span>
       </div>
     </Transition>
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,9 +3,9 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
-const SANITY_PROJECT_ID = process.env['VITE_SANITY_PROJECT_ID'] ?? '5ibtsfdc'
+const SANITY_PROJECT_ID = process.env['VITE_SANITY_PROJECT_ID']
 const SANITY_TOKEN = process.env['SANITY_TOKEN'] ?? ''
-const SANITY_DATASET = process.env['VITE_SANITY_DATASET'] ?? 'dev'
+const SANITY_DATASET = process.env['VITE_SANITY_DATASET'] ?? 'production'
 const SANITY_DOCUMENT_TYPE = process.env['VITE_SANITY_DOCUMENT_TYPE'] ?? 'blog'
 const SANITY_TITLE_FIELD = process.env['VITE_SANITY_TITLE_FIELD'] ?? 'title'
 const SANITY_BODY_FIELD = process.env['VITE_SANITY_BODY_FIELD'] ?? 'body'

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,6 +6,14 @@ import vue from '@vitejs/plugin-vue'
 const SANITY_PROJECT_ID = process.env['VITE_SANITY_PROJECT_ID'] ?? '5ibtsfdc'
 const SANITY_TOKEN = process.env['SANITY_TOKEN'] ?? ''
 const SANITY_DATASET = process.env['VITE_SANITY_DATASET'] ?? 'dev'
+const SANITY_DOCUMENT_TYPE = process.env['VITE_SANITY_DOCUMENT_TYPE'] ?? 'blog'
+const SANITY_TITLE_FIELD = process.env['VITE_SANITY_TITLE_FIELD'] ?? 'title'
+const SANITY_BODY_FIELD = process.env['VITE_SANITY_BODY_FIELD'] ?? 'body'
+const SANITY_SLUG_FIELD = process.env['VITE_SANITY_SLUG_FIELD'] ?? 'slug'
+const SANITY_PUBLISHED_AT_FIELD = process.env['VITE_SANITY_PUBLISHED_AT_FIELD'] ?? 'publishedAt'
+const SANITY_DRAFT_PREFIX = process.env['VITE_SANITY_DRAFT_PREFIX'] ?? 'drafts.'
+const AUTH_LOGIN_PATH = process.env['VITE_AUTH_LOGIN_PATH'] ?? '/.auth/login/aad'
+const AUTH_LOGOUT_PATH = process.env['VITE_AUTH_LOGOUT_PATH'] ?? '/.auth/logout'
 
 // ── Dev auth mock ─────────────────────────────────────────────────────────────
 // In development, emulate the SWA auth and API endpoints so we don't need the
@@ -42,14 +50,14 @@ function devAuthPlugin(): Plugin {
         res.end(JSON.stringify({ clientPrincipal: mockPrincipal }))
       })
 
-      // GET /.auth/login/aad — redirect to home (already "signed in")
-      server.middlewares.use('/.auth/login/aad', (_req, res) => {
+      // GET auth login endpoint — redirect to home (already "signed in")
+      server.middlewares.use(AUTH_LOGIN_PATH, (_req, res) => {
         res.writeHead(302, { Location: '/' })
         res.end()
       })
 
-      // GET /.auth/logout — redirect to home
-      server.middlewares.use('/.auth/logout', (_req, res) => {
+      // GET auth logout endpoint — redirect to home
+      server.middlewares.use(AUTH_LOGOUT_PATH, (_req, res) => {
         res.writeHead(302, { Location: '/' })
         res.end()
       })
@@ -152,7 +160,7 @@ function devAuthPlugin(): Plugin {
 
           if (publishMatch && req.method === 'POST') {
             // Publish a draft document
-            if (!id.startsWith('drafts.')) {
+            if (!id.startsWith(SANITY_DRAFT_PREFIX)) {
               res.writeHead(400, { 'Content-Type': 'application/json' })
               res.end(JSON.stringify({ error: 'Document is not a draft' }))
               return
@@ -163,7 +171,7 @@ function devAuthPlugin(): Plugin {
               res.end(JSON.stringify({ error: 'Draft not found' }))
               return
             }
-            const publishedId = id.slice('drafts.'.length)
+            const publishedId = id.slice(SANITY_DRAFT_PREFIX.length)
             const fields = Object.fromEntries(
               Object.entries(draft).filter(([k]) => k !== '_id' && k !== '_rev'),
             )
@@ -178,12 +186,12 @@ function devAuthPlugin(): Plugin {
             // Create draft
             const body = await readBody(req)
             const { title, slug } = JSON.parse(body)
-            const docId = `drafts.${crypto.randomUUID()}`
+            const docId = `${SANITY_DRAFT_PREFIX}${crypto.randomUUID()}`
             const doc = await client.create({
               _id: docId,
-              _type: 'blog',
-              title,
-              slug: { _type: 'slug', current: slug },
+              _type: SANITY_DOCUMENT_TYPE,
+              [SANITY_TITLE_FIELD]: title,
+              [SANITY_SLUG_FIELD]: { _type: 'slug', current: slug },
             })
             res.writeHead(201, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify(doc))
@@ -193,24 +201,24 @@ function devAuthPlugin(): Plugin {
             const { blocks, title } = JSON.parse(body)
             const fields: Record<string, unknown> = {}
             if (Array.isArray(blocks)) {
-              fields['body'] = blocks
+              fields[SANITY_BODY_FIELD] = blocks
             }
             if (typeof title === 'string') {
-              fields['title'] = title
+              fields[SANITY_TITLE_FIELD] = title
             }
             await client.patch(id).set(fields).commit()
             res.writeHead(204)
             res.end()
           } else if (req.method === 'GET' && !id) {
-            // List blog documents (authenticated — includes drafts)
+            // List documents (authenticated — includes drafts)
             const docs = await client.fetch(
-              `*[_type == "blog"] | order(coalesce(publishedAt, _createdAt) desc) {
+              `*[_type == "${SANITY_DOCUMENT_TYPE}"] | order(coalesce(${SANITY_PUBLISHED_AT_FIELD}, _createdAt) desc) {
                 _id,
                 _createdAt,
                 _updatedAt,
-                publishedAt,
-                title,
-                "body": body[_type == "block"][0..10]
+                "publishedAt": ${SANITY_PUBLISHED_AT_FIELD},
+                "title": ${SANITY_TITLE_FIELD},
+                "body": ${SANITY_BODY_FIELD}[_type == "block"][0..10]
               }`,
             )
             res.writeHead(200, { 'Content-Type': 'application/json' })


### PR DESCRIPTION
This change defines a typed runtime configuration contract so Earnesty can be reused across deployments without editing hardcoded branding, schema, auth, and environment values. It centralizes runtime settings and makes invalid or missing configuration fail fast with explicit errors.

## What changed
- Added dedicated runtime config modules for frontend and API:
  - `app/src/config/runtime.ts`
  - `app/api/src/config/runtime.ts`
- Rewired frontend and API consumers to use contract values instead of inline literals for:
  - Sanity document type/fields and draft prefix
  - Auth login/logout route paths and redirect parameter
  - App branding text and intro defaults
  - Telemetry connection-string wiring
- Updated Vite dev mock behavior to follow the same config contract defaults.
- Added config-focused tests for frontend/API runtime parsing and validation.
- Updated `.env` and README documentation with required/optional keys, defaults, and migration guidance.

## Notes for reviewers
- Validation is intentionally strict in production: missing required keys and malformed config values error explicitly.
- Test mode preserves compatibility by allowing placeholder values where required keys are absent, so existing unit tests stay stable.
- This keeps current behavior by default, while enabling schema/auth/branding overrides through environment configuration.

Fixes: #143