### PR TITLE
refactor: abstract SWA-specific authentication boundaries

### DIFF
--- a/app/api/src/__tests__/createDraft.test.ts
+++ b/app/api/src/__tests__/createDraft.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -22,7 +22,7 @@ vi.mock('@azure/functions', () => ({
 
 vi.mock('../shared.js', () => ({
   getSanityClient: vi.fn(),
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 beforeAll(async () => {
@@ -60,11 +60,13 @@ const CREATED_DOC = {
 
 describe('createDraft handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(VALID_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getHandler()(makeRequest({ body: { title: 'Test', slug: 'test' } }))
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/__tests__/getUser.test.ts
+++ b/app/api/src/__tests__/getUser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { parseClientPrincipal } from '../shared.js'
+import { requireAuthenticatedPrincipal } from '../shared.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -21,7 +21,7 @@ vi.mock('@azure/functions', () => ({
 }))
 
 vi.mock('../shared.js', () => ({
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 beforeAll(async () => {
@@ -49,11 +49,13 @@ const MOCK_PRINCIPAL = {
 
 describe('getUser handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(MOCK_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: MOCK_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getHandler()(makeRequest())
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/__tests__/listDocuments.test.ts
+++ b/app/api/src/__tests__/listDocuments.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -22,7 +22,7 @@ vi.mock('@azure/functions', () => ({
 
 vi.mock('../shared.js', () => ({
   getSanityClient: vi.fn(),
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 beforeAll(async () => {
@@ -53,11 +53,13 @@ function makeRequest(authenticated = true): HttpRequest {
 
 describe('listDocuments handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(VALID_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getHandler()(makeRequest(false))
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/__tests__/listImages.test.ts
+++ b/app/api/src/__tests__/listImages.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -22,7 +22,7 @@ vi.mock('@azure/functions', () => ({
 
 vi.mock('../shared.js', () => ({
   getSanityClient: vi.fn(),
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 beforeAll(async () => {
@@ -53,11 +53,13 @@ function makeRequest(authenticated = true): HttpRequest {
 
 describe('listImages handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(VALID_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getHandler()(makeRequest(false))
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/__tests__/publishDocument.test.ts
+++ b/app/api/src/__tests__/publishDocument.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -22,7 +22,7 @@ vi.mock('@azure/functions', () => ({
 
 vi.mock('../shared.js', () => ({
   getSanityClient: vi.fn(),
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 beforeAll(async () => {
@@ -79,11 +79,13 @@ function makeTransactionClient(opts?: {
 
 describe('publishDocument handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(VALID_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/__tests__/saveDocument.test.ts
+++ b/app/api/src/__tests__/saveDocument.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 // vi.hoisted() ensures these helpers exist when the vi.mock() factory runs.
 const { getHandler, setHandler } = vi.hoisted(() => {
@@ -23,7 +23,7 @@ vi.mock('@azure/functions', () => ({
 
 vi.mock('../shared.js', () => ({
   getSanityClient: vi.fn(),
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 beforeAll(async () => {
@@ -67,11 +67,13 @@ const VALID_PRINCIPAL = {
 
 describe('saveDocument handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(VALID_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getHandler()(makeRequest({ params: { id: 'doc-123' } }))
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/__tests__/shared.test.ts
+++ b/app/api/src/__tests__/shared.test.ts
@@ -1,18 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { parseClientPrincipal } from '../shared.js'
+import { parseSwaClientPrincipal } from '../auth/providers/swa.js'
 
-describe('parseClientPrincipal', () => {
+describe('parseSwaClientPrincipal', () => {
   it('returns null when header is null', () => {
-    expect(parseClientPrincipal(null)).toBeNull()
+    expect(parseSwaClientPrincipal(null)).toBeNull()
   })
 
   it('returns null for invalid base64', () => {
-    expect(parseClientPrincipal('not valid base64!!!')).toBeNull()
+    expect(parseSwaClientPrincipal('not valid base64!!!')).toBeNull()
   })
 
   it('returns null for valid base64 but invalid JSON', () => {
     const invalid = Buffer.from('not json at all').toString('base64')
-    expect(parseClientPrincipal(invalid)).toBeNull()
+    expect(parseSwaClientPrincipal(invalid)).toBeNull()
   })
 
   it('parses a valid base64-encoded principal', () => {
@@ -24,7 +24,7 @@ describe('parseClientPrincipal', () => {
       claims: [{ typ: 'name', val: 'Test User' }],
     }
     const encoded = Buffer.from(JSON.stringify(principal)).toString('base64')
-    expect(parseClientPrincipal(encoded)).toEqual(principal)
+    expect(parseSwaClientPrincipal(encoded)).toEqual(principal)
   })
 })
 

--- a/app/api/src/__tests__/uploadImage.test.ts
+++ b/app/api/src/__tests__/uploadImage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { fileTypeFromBuffer } from 'file-type'
 
 // vi.hoisted() ensures these helpers exist when the vi.mock() factory runs.
@@ -24,7 +24,7 @@ vi.mock('@azure/functions', () => ({
 
 vi.mock('../shared.js', () => ({
   getSanityClient: vi.fn(),
-  parseClientPrincipal: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
 }))
 
 // Mock file-type to control magic-byte detection in unit tests
@@ -87,11 +87,13 @@ function makeRequest(options: {
 
 describe('uploadImage handler', () => {
   beforeEach(() => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(VALID_PRINCIPAL)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
   })
 
   it('returns 401 when not authenticated', async () => {
-    vi.mocked(parseClientPrincipal).mockReturnValue(null)
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
     const res = await getUploadHandler()(makeRequest({}))
     expect(res.status).toBe(401)
     expect(res.jsonBody).toEqual({ error: 'Not authenticated' })

--- a/app/api/src/auth/provider.ts
+++ b/app/api/src/auth/provider.ts
@@ -1,0 +1,13 @@
+import type { HttpRequest } from '@azure/functions'
+import type { AuthenticatedPrincipal } from './types.js'
+import { createSwaAuthProvider } from './providers/swa.js'
+
+export interface ApiAuthBoundary {
+  getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null
+}
+
+const authProvider: ApiAuthBoundary = createSwaAuthProvider()
+
+export function getApiAuthBoundary(): ApiAuthBoundary {
+  return authProvider
+}

--- a/app/api/src/auth/providers/swa.ts
+++ b/app/api/src/auth/providers/swa.ts
@@ -1,0 +1,24 @@
+import type { HttpRequest } from '@azure/functions'
+import type { AuthenticatedPrincipal } from '../types.js'
+
+export interface ApiAuthProvider {
+  getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null
+}
+
+export function parseSwaClientPrincipal(header: string | null): AuthenticatedPrincipal | null {
+  if (!header) return null
+  try {
+    const decoded = Buffer.from(header, 'base64').toString('utf-8')
+    return JSON.parse(decoded) as AuthenticatedPrincipal
+  } catch {
+    return null
+  }
+}
+
+export function createSwaAuthProvider(): ApiAuthProvider {
+  return {
+    getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null {
+      return parseSwaClientPrincipal(request.headers.get('x-ms-client-principal'))
+    },
+  }
+}

--- a/app/api/src/auth/types.ts
+++ b/app/api/src/auth/types.ts
@@ -1,0 +1,7 @@
+export interface AuthenticatedPrincipal {
+  identityProvider: string
+  userId: string
+  userDetails: string
+  userRoles: string[]
+  claims: { typ: string; val: string }[]
+}

--- a/app/api/src/functions/createDraft.ts
+++ b/app/api/src/functions/createDraft.ts
@@ -3,7 +3,7 @@ import {
   type HttpRequest,
   type HttpResponseInit,
 } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { getApiRuntimeConfig } from '../config/runtime.js'
 
 app.http('createDraft', {
@@ -13,12 +13,8 @@ app.http('createDraft', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     let body: { title: unknown; slug: unknown }
     try {

--- a/app/api/src/functions/getUser.ts
+++ b/app/api/src/functions/getUser.ts
@@ -3,7 +3,7 @@ import {
   type HttpRequest,
   type HttpResponseInit,
 } from '@azure/functions'
-import { parseClientPrincipal } from '../shared.js'
+import { requireAuthenticatedPrincipal } from '../shared.js'
 
 app.http('getUser', {
   methods: ['GET'],
@@ -12,20 +12,16 @@ app.http('getUser', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     return {
       status: 200,
       jsonBody: {
-        identityProvider: principal.identityProvider,
-        userId: principal.userId,
-        userDetails: principal.userDetails,
-        userRoles: principal.userRoles,
+        identityProvider: auth.principal.identityProvider,
+        userId: auth.principal.userId,
+        userDetails: auth.principal.userDetails,
+        userRoles: auth.principal.userRoles,
       },
     }
   },

--- a/app/api/src/functions/listDocuments.ts
+++ b/app/api/src/functions/listDocuments.ts
@@ -3,7 +3,7 @@ import {
   type HttpRequest,
   type HttpResponseInit,
 } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { getApiRuntimeConfig } from '../config/runtime.js'
 
 app.http('listDocuments', {
@@ -13,12 +13,8 @@ app.http('listDocuments', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     try {
       const config = getApiRuntimeConfig()

--- a/app/api/src/functions/listImages.ts
+++ b/app/api/src/functions/listImages.ts
@@ -3,7 +3,7 @@ import {
   type HttpRequest,
   type HttpResponseInit,
 } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 interface ImageAsset {
   assetRef: string
@@ -19,12 +19,8 @@ app.http('listImages', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     try {
       const assets = await getSanityClient().fetch<

--- a/app/api/src/functions/publishDocument.ts
+++ b/app/api/src/functions/publishDocument.ts
@@ -3,7 +3,7 @@ import {
   type HttpRequest,
   type HttpResponseInit,
 } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { isDraftDocumentId, toPublishedDocumentId } from '../config/runtime.js'
 
 app.http('publishDocument', {
@@ -13,12 +13,8 @@ app.http('publishDocument', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     const id = request.params['id']
     if (!id) {

--- a/app/api/src/functions/saveDocument.ts
+++ b/app/api/src/functions/saveDocument.ts
@@ -3,7 +3,7 @@ import {
   type HttpRequest,
   type HttpResponseInit,
 } from '@azure/functions'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { getApiRuntimeConfig } from '../config/runtime.js'
 
 app.http('saveDocument', {
@@ -13,12 +13,8 @@ app.http('saveDocument', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     const id = request.params['id']
     if (!id) {

--- a/app/api/src/functions/uploadImage.ts
+++ b/app/api/src/functions/uploadImage.ts
@@ -5,7 +5,7 @@ import {
 } from '@azure/functions'
 import busboy from 'busboy'
 import { fileTypeFromBuffer } from 'file-type'
-import { getSanityClient, parseClientPrincipal } from '../shared.js'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 
 const MAX_FILE_SIZE = 16 * 1024 * 1024 // 16 MB
 
@@ -64,12 +64,8 @@ app.http('uploadImage', {
   handler: async (
     request: HttpRequest,
   ): Promise<HttpResponseInit> => {
-    const principal = parseClientPrincipal(
-      request.headers.get('x-ms-client-principal'),
-    )
-    if (!principal) {
-      return { status: 401, jsonBody: { error: 'Not authenticated' } }
-    }
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
 
     const contentType = request.headers.get('content-type') ?? ''
     if (!contentType.includes('multipart/form-data')) {

--- a/app/api/src/shared.ts
+++ b/app/api/src/shared.ts
@@ -1,5 +1,8 @@
 import { createClient, type SanityClient } from '@sanity/client'
+import type { HttpRequest, HttpResponseInit } from '@azure/functions'
 import { getApiRuntimeConfig } from './config/runtime.js'
+import { getApiAuthBoundary } from './auth/provider.js'
+import type { AuthenticatedPrincipal } from './auth/types.js'
 
 let _client: SanityClient | null = null
 
@@ -21,23 +24,12 @@ export function getSanityClient(): SanityClient {
   return _client
 }
 
-export interface ClientPrincipal {
-  identityProvider: string
-  userId: string
-  userDetails: string
-  userRoles: string[]
-  claims: { typ: string; val: string }[]
-}
-
-/** Parses the SWA client principal from the request header. */
-export function parseClientPrincipal(
-  header: string | null,
-): ClientPrincipal | null {
-  if (!header) return null
-  try {
-    const decoded = Buffer.from(header, 'base64').toString('utf-8')
-    return JSON.parse(decoded) as ClientPrincipal
-  } catch {
-    return null
+export function requireAuthenticatedPrincipal(
+  request: HttpRequest,
+): { principal: AuthenticatedPrincipal } | { response: HttpResponseInit } {
+  const principal = getApiAuthBoundary().getPrincipal(request)
+  if (!principal) {
+    return { response: { status: 401, jsonBody: { error: 'Not authenticated' } } }
   }
+  return { principal }
 }

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -3,7 +3,7 @@ import { ref, computed } from 'vue'
 import AppLogo from './AppLogo.vue'
 import UserModal from './UserModal.vue'
 import type { SaveStatus, PublishStatus } from '../stores/editor'
-import type { SwaUser } from '../stores/auth'
+import type { AuthUser } from '../stores/auth'
 import { runtimeConfig } from '../config/runtime'
 
 const isMac = navigator.platform.toUpperCase().includes('MAC')
@@ -13,7 +13,7 @@ const props = defineProps<{
   documentTitle?: string
   saveStatus?: SaveStatus
   publishStatus?: PublishStatus
-  user?: SwaUser
+  user?: AuthUser
   isAuthenticated?: boolean
   hasDocument?: boolean
   canPublish?: boolean

--- a/app/src/components/UserModal.vue
+++ b/app/src/components/UserModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import BaseModal from './BaseModal.vue'
-import type { SwaUser } from '../stores/auth'
+import type { AuthUser } from '../stores/auth'
 
-defineProps<{ user: SwaUser }>()
+defineProps<{ user: AuthUser }>()
 
 const emit = defineEmits<{ close: []; logout: [] }>()
 

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,6 +1,6 @@
 import type { SanityBodyBlock, BlogDocument } from './sanity'
 import { trackException } from './appInsights'
-import { runtimeConfig } from '../config/runtime'
+import { authProvider } from './authProvider'
 
 export interface ImageAsset {
   assetRef: string
@@ -9,8 +9,6 @@ export interface ImageAsset {
   height: number | null
 }
 
-const LOGIN_PATH = runtimeConfig.auth.loginPath
-const POST_LOGIN_REDIRECT_PARAM = runtimeConfig.auth.postLoginRedirectParam
 const REDIRECT_COOLDOWN_MS = 10_000
 const REDIRECT_TS_KEY = '__auth_redirect_ts'
 
@@ -22,12 +20,8 @@ function redirectToLogin(): never {
   }
   sessionStorage.setItem(REDIRECT_TS_KEY, String(now))
 
-  let redirectUri = window.location.pathname + window.location.search + window.location.hash
-  // Ensure the URI is a safe relative path (defence-in-depth against open redirects)
-  if (!redirectUri.startsWith('/') || redirectUri.startsWith('//')) {
-    redirectUri = '/'
-  }
-  window.location.href = `${LOGIN_PATH}?${POST_LOGIN_REDIRECT_PARAM}=${encodeURIComponent(redirectUri)}`
+  const redirectUri = window.location.pathname + window.location.search + window.location.hash
+  window.location.href = authProvider.getLoginUrl(redirectUri)
   throw new Error('Not authenticated')
 }
 
@@ -99,13 +93,6 @@ export async function apiPublishDocument(
   )
 }
 
-export interface SwaUser {
-  identityProvider: string
-  userId: string
-  userDetails: string
-  userRoles: string[]
-}
-
 /** Uploads an image file to Sanity via the API proxy. */
 export async function apiUploadImage(file: File): Promise<ImageAsset> {
   const form = new FormData()
@@ -121,16 +108,4 @@ export async function apiListDocuments(): Promise<BlogDocument[]> {
 /** Fetches all image assets from Sanity via the API proxy. */
 export async function apiListImages(): Promise<ImageAsset[]> {
   return apiFetch<ImageAsset[]>('/api/sanity/images')
-}
-
-/** Fetches the current user from the SWA auth endpoint. */
-export async function apiGetUser(): Promise<SwaUser | null> {
-  try {
-    const res = await fetch('/.auth/me')
-    if (!res.ok) return null
-    const data = (await res.json()) as { clientPrincipal: SwaUser | null }
-    return data.clientPrincipal
-  } catch {
-    return null
-  }
 }

--- a/app/src/services/authProvider.ts
+++ b/app/src/services/authProvider.ts
@@ -1,0 +1,43 @@
+import { runtimeConfig } from '../config/runtime'
+
+export interface AuthUser {
+  identityProvider: string
+  userId: string
+  userDetails: string
+  userRoles: string[]
+}
+
+export interface AuthProvider {
+  getCurrentUser(): Promise<AuthUser | null>
+  getLoginUrl(postLoginRedirectPath: string): string
+  getLogoutUrl(): string
+}
+
+function normalizeRedirectPath(path: string): string {
+  if (!path.startsWith('/') || path.startsWith('//')) return '/'
+  return path
+}
+
+export function createSwaAuthProvider(): AuthProvider {
+  return {
+    async getCurrentUser(): Promise<AuthUser | null> {
+      try {
+        const res = await fetch('/.auth/me')
+        if (!res.ok) return null
+        const data = (await res.json()) as { clientPrincipal: AuthUser | null }
+        return data.clientPrincipal
+      } catch {
+        return null
+      }
+    },
+    getLoginUrl(postLoginRedirectPath: string): string {
+      const redirectPath = normalizeRedirectPath(postLoginRedirectPath)
+      return `${runtimeConfig.auth.loginPath}?${runtimeConfig.auth.postLoginRedirectParam}=${encodeURIComponent(redirectPath)}`
+    },
+    getLogoutUrl(): string {
+      return runtimeConfig.auth.logoutPath
+    },
+  }
+}
+
+export const authProvider: AuthProvider = createSwaAuthProvider()

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -1,29 +1,27 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
-import { apiGetUser, type SwaUser } from '../services/api'
-import { runtimeConfig } from '../config/runtime'
+import { authProvider, type AuthUser } from '../services/authProvider'
 
-export type { SwaUser }
+export type { AuthUser }
 
 export const useAuthStore = defineStore('auth', () => {
-  const user = ref<SwaUser | null>(null)
+  const user = ref<AuthUser | null>(null)
   const loading = ref(true)
 
   const isAuthenticated = computed(() => user.value !== null)
 
   async function initialize() {
     loading.value = true
-    user.value = await apiGetUser()
+    user.value = await authProvider.getCurrentUser()
     loading.value = false
   }
 
   function login() {
-    window.location.href =
-      `${runtimeConfig.auth.loginPath}?${runtimeConfig.auth.postLoginRedirectParam}=/`
+    window.location.href = authProvider.getLoginUrl('/')
   }
 
   function logout() {
-    window.location.href = runtimeConfig.auth.logoutPath
+    window.location.href = authProvider.getLogoutUrl()
   }
 
   return { user, loading, isAuthenticated, initialize, login, logout }


### PR DESCRIPTION
## Why
Authentication logic was tightly coupled to Azure Static Web Apps and AAD details across both frontend and API code. This made the core auth flow harder to evolve for other providers.

## What changed
- Added a frontend auth provider contract with an SWA default adapter (`app/src/services/authProvider.ts`) and moved auth store usage to that interface.
- Removed direct SWA endpoint assumptions from core frontend auth flow by routing login redirect handling through the provider.
- Introduced an API auth boundary with provider and principal types (`app/api/src/auth/*`) and centralized handler auth checks via `requireAuthenticatedPrincipal`.
- Updated API handlers to use the shared auth boundary instead of direct per-handler SWA principal parsing.
- Updated auth-related API tests to mock the shared boundary and moved principal parsing tests to the SWA provider parser.

## Notes for reviewers
SWA/AAD behavior is intentionally preserved as the default implementation. This PR focuses on abstraction boundaries, not behavior changes.

## Validation
- `pre-commit run`
- `cd app/api && npm test`
- `cd app && npm test`
- `cd app/api && npm run build`
- `cd app && npm run build`

Fixes: #144