### PR TITLE
chore: harden workflow GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ on:
       - 'app/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy-app:
     name: Build and Deploy App
@@ -22,9 +25,6 @@ jobs:
       !startsWith(github.event.head_commit.message || '', 'chore(main): release')
     runs-on: ubuntu-latest
     environment: production
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Why
CodeQL reported open `actions/missing-workflow-permissions` findings because `app.yml` did not explicitly scope `GITHUB_TOKEN` permissions. This change hardens workflow security by making token scope explicit and least-privilege.

## What changed
- Added workflow-level `permissions` in `.github/workflows/app.yml`:
  - `contents: read`
- Proactively aligned `.github/workflows/deploy.yml` with explicit workflow-level permissions:
  - added `permissions: contents: read`
  - removed the equivalent job-level `permissions` block from `deploy-app` (no behavior change)

## Notes
- Existing workflows that already require broader permissions (`release-please.yml`, `deploy-infra.yml`) were left unchanged.
- This PR is expected to clear the current `actions/missing-workflow-permissions` findings after GitHub re-runs CodeQL on this branch.