### PR TITLE
fix: restore document open flow and CSP-compliant asset loading

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,16 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Apply saved theme before first paint to prevent flash of wrong theme -->
-    <script>
-      ;(function () {
-        try {
-          var s = JSON.parse(localStorage.getItem('ernesty:settings') || '{}')
-          document.documentElement.setAttribute('data-theme', s.theme || 'dark')
-        } catch (e) {
-          document.documentElement.setAttribute('data-theme', 'dark')
-        }
-      })()
-    </script>
+    <script src="/theme-init.js"></script>
     <title>Earnesty — Your space for focused writing</title>
     <meta name="description" content="Earnesty is a clean, distraction-free writing app. Write, save, and revisit your work in a calm and focused environment.">
 

--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -28,7 +28,7 @@
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "strict-origin-when-cross-origin",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://cdn.sanity.io data:; connect-src 'self' https://*.sanity.io https://dc.services.visualstudio.com https://*.in.applicationinsights.azure.com; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://cdn.sanity.io data:; connect-src 'self' https://*.sanity.io https://dc.services.visualstudio.com https://*.in.applicationinsights.azure.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()"
   },
   "mimeTypes": {

--- a/app/public/theme-init.js
+++ b/app/public/theme-init.js
@@ -1,0 +1,8 @@
+;(function () {
+  try {
+    var settings = JSON.parse(localStorage.getItem('ernesty:settings') || '{}')
+    document.documentElement.setAttribute('data-theme', settings.theme || 'dark')
+  } catch (_error) {
+    document.documentElement.setAttribute('data-theme', 'dark')
+  }
+})()

--- a/app/public/theme-init.js
+++ b/app/public/theme-init.js
@@ -1,8 +1,8 @@
 ;(function () {
   try {
-    var settings = JSON.parse(localStorage.getItem('ernesty:settings') || '{}')
-    document.documentElement.setAttribute('data-theme', settings.theme || 'dark')
-  } catch (_error) {
-    document.documentElement.setAttribute('data-theme', 'dark')
+    var settings = JSON.parse(globalThis.localStorage?.getItem('ernesty:settings') || '{}')
+    globalThis.document?.documentElement?.setAttribute('data-theme', settings.theme || 'dark')
+  } catch {
+    globalThis.document?.documentElement?.setAttribute('data-theme', 'dark')
   }
 })()

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -23,6 +23,11 @@ const draftPrefix = runtimeConfig.content.draftPrefix
 
 async function onDocumentSelected(doc: BlogDocument) {
   const full = await fetchBlogDocument(doc._id)
+  if (!full) {
+    console.error('[open] could not fetch selected document', doc._id)
+    trackEvent('document_open_failed_not_found', { documentId: doc._id })
+    return
+  }
   const bodyHtml = portableTextToHtml(full.body)
   const titleHtml = `<h1 data-type="title">${escapeHtml(full.title ?? '')}</h1>`
   editorStore.openDocument(full, titleHtml + bodyHtml)

--- a/app/src/services/sanity.ts
+++ b/app/src/services/sanity.ts
@@ -335,7 +335,7 @@ export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
 }
 
 /** Fetch the full body of a single document for editing. */
-export async function fetchBlogDocument(id: string): Promise<BlogDocument> {
+export async function fetchBlogDocument(id: string): Promise<BlogDocument | null> {
   return sanityClient.fetch(
     `*[_type == "${contentConfig.documentType}" && _id == $id][0]{
       _id,


### PR DESCRIPTION
The app was failing in two places after recent changes: CSP blocked required assets, and opening a document could crash when the backend returned `null` for a fetch by id. This PR restores stable document loading and keeps the frontend within the configured CSP.

## What changed
1. Replaced the inline theme bootstrap script in `index.html` with a static `public/theme-init.js` file so `script-src 'self'` is satisfied.
2. Updated `staticwebapp.config.json` CSP to allow Google Fonts stylesheet and font hosts (`fonts.googleapis.com` and `fonts.gstatic.com`).
3. Updated `fetchBlogDocument` to return `BlogDocument | null` and added a guard in `App.vue` to handle missing documents without throwing.

## Notes for reviewers
- The null guard tracks a `document_open_failed_not_found` event instead of crashing.
- No behavior change for valid documents; this only hardens error handling for missing records.