### PR TITLE
ci: enforce SHA pinning for GitHub Actions workflows

### DIFF
--- a/.github/scripts/check-action-sha-pins.sh
+++ b/.github/scripts/check-action-sha-pins.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failed=0
+shopt -s nullglob
+workflow_files=(.github/workflows/*.yml .github/workflows/*.yaml)
+shopt -u nullglob
+
+if [ "${#workflow_files[@]}" -eq 0 ]; then
+  echo "No workflow files found under .github/workflows."
+  exit 0
+fi
+
+for file in "${workflow_files[@]}"; do
+  while IFS=: read -r line_no line_text; do
+    ref=$(
+      printf '%s\n' "$line_text" \
+        | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//; s/[[:space:]]+#.*$//; s/^["'"'"'\'']//; s/["'"'"'\'']$//'
+    )
+
+    if [[ "$ref" == ./* || "$ref" == docker://* ]]; then
+      continue
+    fi
+
+    if [[ ! "$ref" =~ @[0-9a-f]{40}$ ]]; then
+      printf '%s:%s: action reference must be pinned to a 40-char SHA: %s\n' "$file" "$line_no" "$ref"
+      failed=1
+    fi
+  done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^#[:space:]]+' "$file" || true)
+done
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "All third-party GitHub Actions references are SHA-pinned."

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: app
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -38,9 +38,9 @@ jobs:
         working-directory: app
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -60,9 +60,9 @@ jobs:
         working-directory: app/api
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -82,9 +82,9 @@ jobs:
         working-directory: app
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -102,9 +102,9 @@ jobs:
     environment: dev
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -122,7 +122,7 @@ jobs:
           SANITY_TOKEN: ${{ secrets.VITE_SANITY_TOKEN }}
           SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -150,9 +150,9 @@ jobs:
         working-directory: app
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Azure login
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -70,4 +70,3 @@ jobs:
             --deny-settings-mode none \
             --action-on-unmanage detachAll \
             --yes
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,10 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -48,7 +48,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Azure Static Web Apps
-        uses: azure/static-web-apps-deploy@v1
+        uses: azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pin-actions.yml
+++ b/.github/workflows/pin-actions.yml
@@ -1,0 +1,21 @@
+name: Enforce SHA-Pinned Actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check-pinned-actions:
+    name: Check SHA pinning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Validate workflow action pins
+        run: .github/scripts/check-action-sha-pins.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: googleapis/release-please-action@v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,10 @@ repos:
         entry: bash -c 'cd app && npm test'
         pass_filenames: false
         files: ^app/src/.*\.(ts|vue)$
+
+      - id: pin-github-actions
+        name: Enforce SHA-pinned GitHub actions
+        language: system
+        entry: .github/scripts/check-action-sha-pins.sh
+        pass_filenames: false
+        files: ^\.github/workflows/.*\.(yml|yaml)$


### PR DESCRIPTION
## Why
GitHub workflow actions were referenced by moving version tags, which can change over time. This update enforces immutable SHA pinning so CI/CD behavior is reproducible and protected against supply-chain drift.

## What changed
- Added `.github/scripts/check-action-sha-pins.sh` to fail when any third-party `uses:` reference in `.github/workflows` is not pinned to a full 40-character commit SHA.
- Added `.github/workflows/pin-actions.yml` to run the pinning check on pull requests and pushes to `main`.
- Updated all existing third-party workflow action references to SHA-pinned values, keeping prior versions documented in inline comments.
- Added a `pre-commit` hook (`pin-github-actions`) so non-pinned workflow references are caught before commit.

## Notes for reviewers
- Policy is strict by design: no version-tag exceptions for third-party actions.
- Local actions (`./...`) and `docker://` references are intentionally excluded from the pinning check.