### PR TITLE
feat: introduce configurable Sanity schema mapping (type and field flexibility)

### DIFF
--- a/app/api/package-lock.json
+++ b/app/api/package-lock.json
@@ -811,7 +811,6 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",

--- a/app/api/src/__tests__/createDraft.test.ts
+++ b/app/api/src/__tests__/createDraft.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+import { clearApiRuntimeConfigCache } from '../config/runtime.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -170,5 +171,51 @@ describe('createDraft handler', () => {
     const res = await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
     expect(res.status).toBe(502)
     expect(res.jsonBody).toEqual({ error: 'Failed to create draft' })
+  })
+})
+
+// ── Non-default schema mapping ────────────────────────────────────────────────
+
+describe('createDraft handler – custom schema mapping', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      SANITY_DOCUMENT_TYPE: 'article',
+      SANITY_TITLE_FIELD: 'headline',
+      SANITY_SLUG_FIELD: 'path',
+    }
+    clearApiRuntimeConfigCache()
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    clearApiRuntimeConfigCache()
+  })
+
+  it('creates a draft with the configured document type', async () => {
+    const create = vi.fn().mockResolvedValue({ _id: 'drafts.test-id', _type: 'article' })
+    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+
+    await getHandler()(makeRequest({ body: { title: 'My Article', slug: 'my-article' } }))
+
+    const doc = vi.mocked(create).mock.calls[0][0] as Record<string, unknown>
+    expect(doc['_type']).toBe('article')
+  })
+
+  it('uses configured title and slug field names', async () => {
+    const create = vi.fn().mockResolvedValue({ _id: 'drafts.test-id', _type: 'article' })
+    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+
+    await getHandler()(makeRequest({ body: { title: 'My Article', slug: 'my-article' } }))
+
+    const doc = vi.mocked(create).mock.calls[0][0] as Record<string, unknown>
+    expect(doc['headline']).toBe('My Article')
+    expect(doc['path']).toMatchObject({ _type: 'slug', current: 'my-article' })
+    expect(doc).not.toHaveProperty('title')
+    expect(doc).not.toHaveProperty('slug')
   })
 })

--- a/app/api/src/__tests__/listDocuments.test.ts
+++ b/app/api/src/__tests__/listDocuments.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+import { clearApiRuntimeConfigCache } from '../config/runtime.js'
 
 const { getHandler, setHandler } = vi.hoisted(() => {
   let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
@@ -108,5 +109,52 @@ describe('listDocuments handler', () => {
     const query = mockFetch.mock.calls[0][0] as string
     expect(query).toContain('_type == "blog"')
     expect(query).toContain('order(')
+  })
+})
+
+// ── Non-default schema mapping ────────────────────────────────────────────────
+
+describe('listDocuments handler – custom schema mapping', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      SANITY_DOCUMENT_TYPE: 'article',
+      SANITY_TITLE_FIELD: 'headline',
+      SANITY_BODY_FIELD: 'content',
+      SANITY_PUBLISHED_AT_FIELD: 'publishedOn',
+    }
+    clearApiRuntimeConfigCache()
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    clearApiRuntimeConfigCache()
+  })
+
+  it('filters by the configured document type', async () => {
+    const mockFetch = vi.fn().mockResolvedValue([])
+    vi.mocked(getSanityClient).mockReturnValue({ fetch: mockFetch } as any)
+
+    await getHandler()(makeRequest())
+
+    const query = mockFetch.mock.calls[0][0] as string
+    expect(query).toContain('_type == "article"')
+    expect(query).not.toContain('_type == "blog"')
+  })
+
+  it('uses configured field names in the projection', async () => {
+    const mockFetch = vi.fn().mockResolvedValue([])
+    vi.mocked(getSanityClient).mockReturnValue({ fetch: mockFetch } as any)
+
+    await getHandler()(makeRequest())
+
+    const query = mockFetch.mock.calls[0][0] as string
+    expect(query).toContain('"title": headline')
+    expect(query).toContain('"publishedAt": publishedOn')
+    expect(query).toContain('"body": content')
   })
 })

--- a/app/api/src/__tests__/saveDocument.test.ts
+++ b/app/api/src/__tests__/saveDocument.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import type { HttpRequest, HttpResponseInit } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+import { clearApiRuntimeConfigCache } from '../config/runtime.js'
 
 // vi.hoisted() ensures these helpers exist when the vi.mock() factory runs.
 const { getHandler, setHandler } = vi.hoisted(() => {
@@ -193,5 +194,65 @@ describe('saveDocument handler', () => {
 
     expect(res.status).toBe(502)
     expect(res.jsonBody).toEqual({ error: 'Failed to save document' })
+  })
+})
+
+// ── Non-default schema mapping ────────────────────────────────────────────────
+
+describe('saveDocument handler – custom schema mapping', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      SANITY_TITLE_FIELD: 'headline',
+      SANITY_BODY_FIELD: 'content',
+    }
+    clearApiRuntimeConfigCache()
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    clearApiRuntimeConfigCache()
+  })
+
+  it('uses the configured body field name when saving blocks', async () => {
+    const { patch, set } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+
+    const blocks = [{ _type: 'block', children: [] }]
+    await getHandler()(makeRequest({
+      params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
+      body: { blocks },
+    }))
+
+    expect(set).toHaveBeenCalledWith({ content: blocks })
+  })
+
+  it('uses the configured title field name when saving title', async () => {
+    const { patch, set } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+
+    await getHandler()(makeRequest({
+      params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
+      body: { title: 'Updated Headline' },
+    }))
+
+    expect(set).toHaveBeenCalledWith({ headline: 'Updated Headline' })
+  })
+
+  it('uses both configured field names when saving blocks and title together', async () => {
+    const { patch, set } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+
+    const blocks = [{ _type: 'block', children: [] }]
+    await getHandler()(makeRequest({
+      params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
+      body: { blocks, title: 'Updated Headline' },
+    }))
+
+    expect(set).toHaveBeenCalledWith({ content: blocks, headline: 'Updated Headline' })
   })
 })

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -8,7 +8,7 @@ import SettingsModal from './components/SettingsModal.vue'
 import PublishModal from './components/PublishModal.vue'
 import { useEditorStore, type DocumentMeta } from './stores/editor'
 import { useAuthStore } from './stores/auth'
-import { fetchBlogDocument, portableTextToHtml, type BlogDocument } from './services/sanity'
+import { fetchDocument, portableTextToHtml, type ContentDocument } from './services/sanity'
 import { apiPublishDocument, apiSaveDocument } from './services/api'
 import { trackException, trackEvent } from './services/appInsights'
 import { runtimeConfig } from './config/runtime'
@@ -21,8 +21,8 @@ const editorStore = useEditorStore()
 const auth = useAuthStore()
 const draftPrefix = runtimeConfig.content.draftPrefix
 
-async function onDocumentSelected(doc: BlogDocument) {
-  const full = await fetchBlogDocument(doc._id)
+async function onDocumentSelected(doc: ContentDocument) {
+  const full = await fetchDocument(doc._id)
   if (!full) {
     console.error('[open] could not fetch selected document', doc._id)
     trackEvent('document_open_failed_not_found', { documentId: doc._id })
@@ -108,7 +108,7 @@ async function doPublish() {
   editorStore.setPublishStatus('publishing')
   try {
     const { _id: publishedId } = await apiPublishDocument(doc._id)
-    const published = await fetchBlogDocument(publishedId)
+    const published = await fetchDocument(publishedId)
     if (!published) {
       console.error('[publish] could not fetch published document', publishedId)
       editorStore.setPublishStatus('error')

--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import BaseModal from './BaseModal.vue'
-import { useBlogDocuments } from '../composables/useBlogDocuments'
-import { extractPreview, type BlogDocument } from '../services/sanity'
+import { useDocuments } from '../composables/useBlogDocuments'
+import { extractPreview, type ContentDocument } from '../services/sanity'
 import { runtimeConfig } from '../config/runtime'
 
 const emit = defineEmits<{
   close: []
-  select: [doc: BlogDocument]
+  select: [doc: ContentDocument]
 }>()
 
-const { documents, loading, error } = useBlogDocuments()
+const { documents, loading, error } = useDocuments()
 const draftPrefix = runtimeConfig.content.draftPrefix
 
 // ── Search & sort ─────────────────────────────────────────────────────────────
@@ -30,8 +30,8 @@ const sortOptions: { value: SortKey; label: string }[] = [
 
 // Deduplicate draft/published pairs and compute status for each document.
 // When both draft and published exist, prefer the draft (it has the latest edits).
-const resolvedDocs = computed<{ doc: BlogDocument; status: DocStatus }[]>(() => {
-  const map = new Map<string, { draft?: BlogDocument; published?: BlogDocument }>()
+const resolvedDocs = computed<{ doc: ContentDocument; status: DocStatus }[]>(() => {
+  const map = new Map<string, { draft?: ContentDocument; published?: ContentDocument }>()
 
   for (const doc of documents.value) {
     const isDraft = doc._id.startsWith(draftPrefix)
@@ -88,7 +88,7 @@ function formatDate(iso: string) {
   })
 }
 
-function select(doc: BlogDocument) {
+function select(doc: ContentDocument) {
   emit('select', doc)
   emit('close')
 }

--- a/app/src/composables/useBlogDocuments.ts
+++ b/app/src/composables/useBlogDocuments.ts
@@ -1,9 +1,9 @@
 import { ref, onMounted } from 'vue'
-import type { BlogDocument } from '../services/sanity'
+import type { ContentDocument } from '../services/sanity'
 import { apiListDocuments } from '../services/api'
 
-export function useBlogDocuments() {
-  const documents = ref<BlogDocument[]>([])
+export function useDocuments() {
+  const documents = ref<ContentDocument[]>([])
   const loading = ref(true)
   const error = ref<string | null>(null)
 
@@ -11,7 +11,7 @@ export function useBlogDocuments() {
     try {
       documents.value = await apiListDocuments()
     } catch (e) {
-      console.error('[useBlogDocuments] fetch failed:', e)
+      console.error('[useDocuments] fetch failed:', e)
       const msg = e instanceof Error ? e.message : String(e)
       error.value = `Could not load documents: ${msg}`
     } finally {
@@ -21,3 +21,6 @@ export function useBlogDocuments() {
 
   return { documents, loading, error }
 }
+
+/** @deprecated Use {@link useDocuments} instead. */
+export const useBlogDocuments = useDocuments

--- a/app/src/services/__tests__/sanity.integration.test.ts
+++ b/app/src/services/__tests__/sanity.integration.test.ts
@@ -3,7 +3,7 @@
  *
  * These tests run against the real Sanity development dataset. They use an
  * admin client (SANITY_TOKEN) to create and clean up test data, then verify
- * that fetchBlogDocuments and fetchBlogDocument can read it via the
+ * that fetchDocuments and fetchDocument can read it via the
  * unauthenticated public client in sanity.ts.
  *
  * Required environment variables:
@@ -16,7 +16,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { createClient } from '@sanity/client'
-import { fetchBlogDocuments, fetchBlogDocument } from '../sanity.js'
+import { fetchDocuments, fetchDocument } from '../sanity.js'
 
 const projectId = import.meta.env.VITE_SANITY_PROJECT_ID as string | undefined
 const dataset = (import.meta.env.VITE_SANITY_DATASET as string | undefined) ?? 'production'
@@ -27,7 +27,7 @@ const adminToken = process.env['SANITY_TOKEN']
 const hasCredentials = Boolean(projectId && adminToken)
 
 const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
-// Use a published (non-draft) ID so the GROQ query in fetchBlogDocuments finds it.
+// Use a published (non-draft) ID so the GROQ query in fetchDocuments finds it.
 const TEST_DOC_ID = `integration-fe-${RUN_ID}`
 
 describe.skipIf(!hasCredentials)('Integration: Sanity fetch functions', () => {
@@ -62,23 +62,23 @@ describe.skipIf(!hasCredentials)('Integration: Sanity fetch functions', () => {
     await adminClient.delete(TEST_DOC_ID).catch(() => {})
   })
 
-  // ── fetchBlogDocuments ───────────────────────────────────────────────────────
+  // ── fetchDocuments ───────────────────────────────────────────────────────
 
-  describe('fetchBlogDocuments', () => {
+  describe('fetchDocuments', () => {
     it('returns an array', async () => {
-      const docs = await fetchBlogDocuments()
+      const docs = await fetchDocuments()
       expect(Array.isArray(docs)).toBe(true)
     })
 
     it('includes the test document in the results', async () => {
-      const docs = await fetchBlogDocuments()
+      const docs = await fetchDocuments()
       const found = docs.find((d) => d._id === TEST_DOC_ID)
       expect(found).toBeDefined()
       expect(found?.title).toBe('Integration Fetch Test')
     })
 
     it('returns documents with the expected shape', async () => {
-      const docs = await fetchBlogDocuments()
+      const docs = await fetchDocuments()
       expect(docs.length).toBeGreaterThan(0)
       const doc = docs[0]
       expect(doc).toHaveProperty('_id')
@@ -88,18 +88,18 @@ describe.skipIf(!hasCredentials)('Integration: Sanity fetch functions', () => {
     })
   })
 
-  // ── fetchBlogDocument ────────────────────────────────────────────────────────
+  // ── fetchDocument ────────────────────────────────────────────────────────
 
-  describe('fetchBlogDocument', () => {
+  describe('fetchDocument', () => {
     it('retrieves the test document by ID', async () => {
-      const doc = await fetchBlogDocument(TEST_DOC_ID)
+      const doc = await fetchDocument(TEST_DOC_ID)
       expect(doc).not.toBeNull()
       expect(doc._id).toBe(TEST_DOC_ID)
       expect(doc.title).toBe('Integration Fetch Test')
     })
 
     it('returns the full body of the document', async () => {
-      const doc = await fetchBlogDocument(TEST_DOC_ID)
+      const doc = await fetchDocument(TEST_DOC_ID)
       expect(Array.isArray(doc.body)).toBe(true)
       expect(doc.body?.length).toBeGreaterThan(0)
       expect(doc.body?.[0]?._type).toBe('block')

--- a/app/src/services/__tests__/sanity.schema-mapping.test.ts
+++ b/app/src/services/__tests__/sanity.schema-mapping.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests that fetchDocuments and fetchDocument use the configured schema
+ * mapping (documentType, titleField, bodyField, publishedAtField) in GROQ
+ * queries instead of the built-in defaults.
+ *
+ * The config module is mocked at the top level so the module-level
+ * `contentConfig` constant in sanity.ts picks up the custom values on import.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchDocuments, fetchDocument } from '../sanity.js'
+
+const { mockClientFetch, CUSTOM_CONTENT_CONFIG } = vi.hoisted(() => ({
+  mockClientFetch: vi.fn(),
+  CUSTOM_CONTENT_CONFIG: {
+    documentType: 'article',
+    titleField: 'headline',
+    bodyField: 'content',
+    slugField: 'path',
+    publishedAtField: 'publishedOn',
+    draftPrefix: 'drafts.',
+  },
+}))
+
+vi.mock('@sanity/client', () => ({
+  createClient: vi.fn(() => ({ fetch: mockClientFetch })),
+}))
+
+vi.mock('../../config/runtime.js', () => ({
+  runtimeConfig: {
+    content: CUSTOM_CONTENT_CONFIG,
+    sanity: {
+      projectId: 'custom-project',
+      dataset: 'production',
+      apiVersion: '2024-01-01',
+      useProxy: false,
+    },
+    app: { name: 'Test' },
+    auth: { loginPath: '/.auth/login/aad', logoutPath: '/.auth/logout', postLoginRedirectParam: 'post_login_redirect_uri' },
+    telemetry: {},
+  },
+  isDraftDocumentId: vi.fn((id: string) => id.startsWith('drafts.')),
+  toPublishedDocumentId: vi.fn((id: string) => id.replace(/^drafts\./, '')),
+  draftDocumentIdPattern: vi.fn(() => /^drafts\..+$/),
+}))
+
+// ── fetchDocuments with custom mapping ────────────────────────────────────────
+
+describe('fetchDocuments – custom schema mapping', () => {
+  beforeEach(() => {
+    mockClientFetch.mockReset()
+  })
+
+  it('uses the configured document type in the GROQ filter', async () => {
+    mockClientFetch.mockResolvedValue([])
+    await fetchDocuments()
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('_type == "article"')
+    expect(query).not.toContain('_type == "blog"')
+  })
+
+  it('aliases the configured title field to "title" in the projection', async () => {
+    mockClientFetch.mockResolvedValue([])
+    await fetchDocuments()
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('"title": headline')
+  })
+
+  it('aliases the configured body field to "body" in the projection', async () => {
+    mockClientFetch.mockResolvedValue([])
+    await fetchDocuments()
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('"body": content')
+  })
+
+  it('aliases the configured publishedAt field to "publishedAt" in the projection', async () => {
+    mockClientFetch.mockResolvedValue([])
+    await fetchDocuments()
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('"publishedAt": publishedOn')
+  })
+
+  it('orders by the configured publishedAt field', async () => {
+    mockClientFetch.mockResolvedValue([])
+    await fetchDocuments()
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('publishedOn')
+    expect(query).toContain('order(')
+  })
+})
+
+// ── fetchDocument with custom mapping ────────────────────────────────────────
+
+describe('fetchDocument – custom schema mapping', () => {
+  beforeEach(() => {
+    mockClientFetch.mockReset()
+  })
+
+  it('uses the configured document type in the GROQ filter', async () => {
+    mockClientFetch.mockResolvedValue(null)
+    await fetchDocument('doc-1')
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('_type == "article"')
+    expect(query).not.toContain('_type == "blog"')
+  })
+
+  it('aliases the configured title field to "title" in the projection', async () => {
+    mockClientFetch.mockResolvedValue(null)
+    await fetchDocument('doc-1')
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('"title": headline')
+  })
+
+  it('aliases the configured body field to "body" in the projection', async () => {
+    mockClientFetch.mockResolvedValue(null)
+    await fetchDocument('doc-1')
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('"body": content')
+  })
+
+  it('aliases the configured publishedAt field to "publishedAt" in the projection', async () => {
+    mockClientFetch.mockResolvedValue(null)
+    await fetchDocument('doc-1')
+
+    const query = mockClientFetch.mock.calls[0][0] as string
+    expect(query).toContain('"publishedAt": publishedOn')
+  })
+})

--- a/app/src/services/__tests__/sanity.test.ts
+++ b/app/src/services/__tests__/sanity.test.ts
@@ -4,8 +4,8 @@ import {
   tiptapJsonToPortableText,
   buildSanityImageUrl,
   extractPreview,
-  fetchBlogDocuments,
-  fetchBlogDocument,
+  fetchDocuments,
+  fetchDocument,
   type SanityBodyBlock,
   type SanityBlock,
   type TiptapNode,
@@ -432,27 +432,27 @@ describe('tiptapJsonToPortableText', () => {
   })
 })
 
-// ── fetchBlogDocuments ────────────────────────────────────────────────────────
+// ── fetchDocuments ────────────────────────────────────────────────────────────
 
-describe('fetchBlogDocuments', () => {
+describe('fetchDocuments', () => {
   beforeEach(() => {
     mockClientFetch.mockReset()
   })
 
-  it('returns the list of blog documents', async () => {
+  it('returns the list of content documents', async () => {
     const mockDocs = [
       { _id: 'doc-1', title: 'First Post', _createdAt: '2024-01-01', _updatedAt: '2024-01-01' },
       { _id: 'doc-2', title: 'Second Post', _createdAt: '2024-01-02', _updatedAt: '2024-01-02' },
     ]
     mockClientFetch.mockResolvedValue(mockDocs)
 
-    const docs = await fetchBlogDocuments()
+    const docs = await fetchDocuments()
     expect(docs).toEqual(mockDocs)
   })
 
   it('queries Sanity with a GROQ expression', async () => {
     mockClientFetch.mockResolvedValue([])
-    await fetchBlogDocuments()
+    await fetchDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
     expect(query).toMatch(/^\s*\*\[/)
@@ -461,7 +461,7 @@ describe('fetchBlogDocuments', () => {
 
   it('orders results by published date descending', async () => {
     mockClientFetch.mockResolvedValue([])
-    await fetchBlogDocuments()
+    await fetchDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
     expect(query).toContain('order(')
@@ -469,9 +469,9 @@ describe('fetchBlogDocuments', () => {
   })
 })
 
-// ── fetchBlogDocument ─────────────────────────────────────────────────────────
+// ── fetchDocument ─────────────────────────────────────────────────────────────
 
-describe('fetchBlogDocument', () => {
+describe('fetchDocument', () => {
   beforeEach(() => {
     mockClientFetch.mockReset()
   })
@@ -480,13 +480,13 @@ describe('fetchBlogDocument', () => {
     const mockDoc = { _id: 'doc-1', title: 'My Post', _createdAt: '2024-01-01', _updatedAt: '2024-01-01', body: [] }
     mockClientFetch.mockResolvedValue(mockDoc)
 
-    const doc = await fetchBlogDocument('doc-1')
+    const doc = await fetchDocument('doc-1')
     expect(doc).toEqual(mockDoc)
   })
 
   it('passes the document ID as a GROQ parameter', async () => {
     mockClientFetch.mockResolvedValue(null)
-    await fetchBlogDocument('my-doc-id')
+    await fetchDocument('my-doc-id')
 
     const params = mockClientFetch.mock.calls[0][1] as Record<string, string>
     expect(params).toMatchObject({ id: 'my-doc-id' })
@@ -494,7 +494,7 @@ describe('fetchBlogDocument', () => {
 
   it('queries by _id using a GROQ expression', async () => {
     mockClientFetch.mockResolvedValue(null)
-    await fetchBlogDocument('doc-1')
+    await fetchDocument('doc-1')
 
     const query = mockClientFetch.mock.calls[0][0] as string
     expect(query).toContain('_id == $id')

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { SanityBodyBlock, BlogDocument } from './sanity'
+import type { SanityBodyBlock, ContentDocument } from './sanity'
 import { trackException } from './appInsights'
 import { authProvider } from './authProvider'
 
@@ -72,12 +72,12 @@ export async function apiSaveDocument(
   })
 }
 
-/** Creates a new blog draft via the API proxy. */
+/** Creates a new content draft via the API proxy. */
 export async function apiCreateDraft(
   title: string,
   slug: string,
-): Promise<BlogDocument> {
-  return apiFetch<BlogDocument>('/api/sanity/documents', {
+): Promise<ContentDocument> {
+  return apiFetch<ContentDocument>('/api/sanity/documents', {
     method: 'POST',
     body: JSON.stringify({ title, slug }),
   })
@@ -100,9 +100,9 @@ export async function apiUploadImage(file: File): Promise<ImageAsset> {
   return apiFetch<ImageAsset>('/api/sanity/images', { method: 'POST', body: form })
 }
 
-/** Fetches all blog documents (including drafts) via the API proxy. */
-export async function apiListDocuments(): Promise<BlogDocument[]> {
-  return apiFetch<BlogDocument[]>('/api/sanity/documents')
+/** Fetches all content documents (including drafts) via the API proxy. */
+export async function apiListDocuments(): Promise<ContentDocument[]> {
+  return apiFetch<ContentDocument[]>('/api/sanity/documents')
 }
 
 /** Fetches all image assets from Sanity via the API proxy. */

--- a/app/src/services/sanity.ts
+++ b/app/src/services/sanity.ts
@@ -59,7 +59,7 @@ export interface SanityCodeBlock {
 
 export type SanityBodyBlock = SanityBlock | SanityImageBlock | SanityCodeBlock
 
-export interface BlogDocument {
+export interface ContentDocument {
   _id: string
   _createdAt: string
   _updatedAt: string
@@ -67,6 +67,9 @@ export interface BlogDocument {
   title: string
   body?: SanityBodyBlock[]
 }
+
+/** @deprecated Use {@link ContentDocument} instead. */
+export type BlogDocument = ContentDocument
 
 /** Converts a Sanity image asset ref to a CDN URL. */
 export function buildSanityImageUrl(ref: string): string {
@@ -320,8 +323,8 @@ function key() {
 
 // ── Queries ───────────────────────────────────────────────────────────────────
 
-/** Fetch list of blog documents (title + enough body blocks for 50-word preview). */
-export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
+/** Fetch list of content documents (title + enough body blocks for 50-word preview). */
+export async function fetchDocuments(): Promise<ContentDocument[]> {
   return sanityClient.fetch(`
     *[_type == "${contentConfig.documentType}"] | order(coalesce(${contentConfig.publishedAtField}, _createdAt) desc) {
       _id,
@@ -334,8 +337,11 @@ export async function fetchBlogDocuments(): Promise<BlogDocument[]> {
   `)
 }
 
+/** @deprecated Use {@link fetchDocuments} instead. */
+export const fetchBlogDocuments = fetchDocuments
+
 /** Fetch the full body of a single document for editing. */
-export async function fetchBlogDocument(id: string): Promise<BlogDocument | null> {
+export async function fetchDocument(id: string): Promise<ContentDocument | null> {
   return sanityClient.fetch(
     `*[_type == "${contentConfig.documentType}" && _id == $id][0]{
       _id,
@@ -348,3 +354,6 @@ export async function fetchBlogDocument(id: string): Promise<BlogDocument | null
     { id },
   )
 }
+
+/** @deprecated Use {@link fetchDocument} instead. */
+export const fetchBlogDocument = fetchDocument

--- a/app/src/stores/editor.ts
+++ b/app/src/stores/editor.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, shallowRef } from 'vue'
-import type { BlogDocument } from '../services/sanity'
+import type { ContentDocument } from '../services/sanity'
 import { INTRO_HTML } from '../constants'
 
 export interface DocumentMeta {
@@ -14,7 +14,7 @@ const SESSION_KEY = 'earnesty-session'
 export const CONTENT_KEY = 'earnesty-content'
 
 interface PersistedSession {
-  activeDocument: BlogDocument | null
+  activeDocument: ContentDocument | null
   meta: DocumentMeta
 }
 
@@ -27,7 +27,7 @@ function loadSession(): PersistedSession | null {
   }
 }
 
-function saveSession(doc: BlogDocument | null, m: DocumentMeta) {
+function saveSession(doc: ContentDocument | null, m: DocumentMeta) {
   localStorage.setItem(SESSION_KEY, JSON.stringify({ activeDocument: doc, meta: m }))
 }
 
@@ -46,7 +46,7 @@ export type PublishStatus = 'idle' | 'publishing' | 'published' | 'error'
 export const useEditorStore = defineStore('editor', () => {
   const saved = loadSession()
 
-  const activeDocument = ref<BlogDocument | null>(saved?.activeDocument ?? null)
+  const activeDocument = ref<ContentDocument | null>(saved?.activeDocument ?? null)
   const currentContent = ref<string>('')
   const pendingHtml = ref<string | null>(null)
   const saveStatus = ref<SaveStatus>('idle')
@@ -58,7 +58,7 @@ export const useEditorStore = defineStore('editor', () => {
   /** Registered by HomeView to flush pending autosave before publish. */
   const flushSave = shallowRef<(() => Promise<void>) | null>(null)
 
-  function openDocument(doc: BlogDocument, html?: string) {
+  function openDocument(doc: ContentDocument, html?: string) {
     activeDocument.value = doc
     meta.value = {
       title: doc.title ?? '',


### PR DESCRIPTION
Closes #145
Parent: #141

## Summary

Completes the schema mapping work started in #143 by removing the last hardcoded `blog` assumptions from exported symbols and adding full test coverage for non-default schema configurations.

## Changes

### Renamed symbols (backward-compatible deprecated aliases kept)

| Old name | New name |
|---|---|
| `BlogDocument` | `ContentDocument` |
| `fetchBlogDocuments` | `fetchDocuments` |
| `fetchBlogDocument` | `fetchDocument` |
| `useBlogDocuments` | `useDocuments` |

All callers updated: `App.vue`, `OpenDocumentModal.vue`, `stores/editor.ts`, `services/api.ts`, integration tests.

### New test coverage — non-default schema mapping

**API handler tests** (`listDocuments`, `createDraft`, `saveDocument`) each gain a `describe('… custom schema mapping')` block that sets non-default env vars (`SANITY_DOCUMENT_TYPE=article`, `SANITY_TITLE_FIELD=headline`, etc.) and verifies:
- GROQ queries filter by the configured `documentType`
- Projections use configured field names
- `createDraft` and `saveDocument` write to the right fields

**Frontend service tests** — new `sanity.schema-mapping.test.ts` mocks `config/runtime.js` with custom values and verifies that `fetchDocuments` and `fetchDocument` embed those values in their GROQ queries.

## Test results

```
app/     77 passed | 5 skipped   (+9 new tests)
app/api/ 78 passed | 9 skipped   (+7 new tests)
```