### PR TITLE
feat: decouple hosting/deployment assumptions from Azure-only defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The app and API expose a typed runtime configuration contract so deployments can
 | `VITE_SANITY_SLUG_FIELD` | No | `slug` |
 | `VITE_SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
 | `VITE_SANITY_DRAFT_PREFIX` | No | `drafts.` |
+| `VITE_AUTH_PROVIDER` | No | `swa` |
+| `VITE_AUTH_CURRENT_USER_PATH` | No | `/.auth/me` for `swa`, `/api/me` for `api` |
 | `VITE_AUTH_LOGIN_PATH` | No | `/.auth/login/aad` |
 | `VITE_AUTH_LOGOUT_PATH` | No | `/.auth/logout` |
 | `VITE_AUTH_POST_LOGIN_REDIRECT_PARAM` | No | `post_login_redirect_uri` |
@@ -83,7 +85,7 @@ The app and API expose a typed runtime configuration contract so deployments can
 | `VITE_APP_INTRO_TITLE` | No | `${VITE_APP_NAME} is your space for focused writing` |
 | `VITE_APPLICATIONINSIGHTS_CONNECTION_STRING` | No | unset |
 
-### API / SWA app settings
+### API runtime settings
 
 | Variable | Required | Default |
 |---|---|---|
@@ -97,8 +99,19 @@ The app and API expose a typed runtime configuration contract so deployments can
 | `SANITY_SLUG_FIELD` | No | `slug` |
 | `SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
 | `SANITY_DRAFT_PREFIX` | No | `drafts.` |
+| `AUTH_PROVIDER` | No | `swa` |
+| `AUTH_PRINCIPAL_HEADER` | No | `x-ms-client-principal` for `swa`, `x-authenticated-principal` for `header` |
+| `AUTH_PRINCIPAL_ENCODING` | No | `base64-json` for `swa`, `json` for `header` |
 
 Validation is fail-fast: missing required variables or invalid values (for example malformed field names or draft prefix without a trailing dot) throw explicit startup/runtime errors.
+
+### Portability boundary
+
+The core app now treats authentication and current-user discovery as part of an explicit runtime contract instead of assuming Azure Static Web Apps everywhere:
+
+- **Frontend contract:** the app only requires a current-user endpoint, login path, logout path, and redirect parameter. Azure Static Web Apps remains the default through `VITE_AUTH_PROVIDER=swa`, but alternative hosts can point the app at their own endpoints without changing core UI code.
+- **API contract:** the server only requires an authenticated principal header that can be parsed as either SWA's `x-ms-client-principal` envelope or a plain JSON header, depending on `AUTH_PROVIDER`.
+- **Azure-only adapter surfaces:** `app/public/staticwebapp.config.json`, `app/api/`'s Azure Functions host, `infra/**`, and `.github/workflows/deploy*.yml` remain the Azure deployment path. Alternative hosting targets should preserve the documented runtime contract or replace these adapters explicitly.
 
 ## Building for production
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -8,6 +8,9 @@ VITE_SANITY_BODY_FIELD=body
 VITE_SANITY_SLUG_FIELD=slug
 VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
 VITE_SANITY_DRAFT_PREFIX=drafts.
+# Optional auth provider/runtime contract
+VITE_AUTH_PROVIDER=swa
+VITE_AUTH_CURRENT_USER_PATH=/.auth/me
 # Optional auth route mapping
 VITE_AUTH_LOGIN_PATH=/.auth/login/aad
 VITE_AUTH_LOGOUT_PATH=/.auth/logout

--- a/app/api/src/__tests__/shared.test.ts
+++ b/app/api/src/__tests__/shared.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { parseHeaderPrincipal } from '../auth/providers/header.js'
 import { parseSwaClientPrincipal } from '../auth/providers/swa.js'
 
 describe('parseSwaClientPrincipal', () => {
@@ -25,6 +26,24 @@ describe('parseSwaClientPrincipal', () => {
     }
     const encoded = Buffer.from(JSON.stringify(principal)).toString('base64')
     expect(parseSwaClientPrincipal(encoded)).toEqual(principal)
+  })
+})
+
+describe('parseHeaderPrincipal', () => {
+  it('parses a valid JSON principal from a plain header', () => {
+    const principal = {
+      identityProvider: 'proxy',
+      userId: 'user-456',
+      userDetails: 'proxy@example.com',
+      userRoles: ['authenticated'],
+      claims: [{ typ: 'name', val: 'Proxy User' }],
+    }
+
+    expect(parseHeaderPrincipal(JSON.stringify(principal), 'json')).toEqual(principal)
+  })
+
+  it('returns null for JSON payloads that do not match the principal contract', () => {
+    expect(parseHeaderPrincipal(JSON.stringify({ userId: 'missing-fields' }), 'json')).toBeNull()
   })
 })
 

--- a/app/api/src/auth/provider.ts
+++ b/app/api/src/auth/provider.ts
@@ -1,13 +1,18 @@
 import type { HttpRequest } from '@azure/functions'
 import type { AuthenticatedPrincipal } from './types.js'
 import { createSwaAuthProvider } from './providers/swa.js'
+import { createHeaderAuthProvider } from './providers/header.js'
+import { getApiRuntimeConfig } from '../config/runtime.js'
 
 export interface ApiAuthBoundary {
   getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null
 }
 
-const authProvider: ApiAuthBoundary = createSwaAuthProvider()
-
 export function getApiAuthBoundary(): ApiAuthBoundary {
-  return authProvider
+  const { auth } = getApiRuntimeConfig()
+  if (auth.provider === 'swa') return createSwaAuthProvider()
+  return createHeaderAuthProvider({
+    headerName: auth.principalHeader,
+    encoding: auth.principalEncoding,
+  })
 }

--- a/app/api/src/auth/providers/header.ts
+++ b/app/api/src/auth/providers/header.ts
@@ -1,0 +1,55 @@
+import type { HttpRequest } from '@azure/functions'
+import type { AuthenticatedPrincipal } from '../types.js'
+import type { ApiAuthProvider } from './swa.js'
+
+export type PrincipalEncoding = 'base64-json' | 'json'
+
+function isClaimsArray(value: unknown): value is AuthenticatedPrincipal['claims'] {
+  return Array.isArray(value)
+    && value.every(
+      (claim) => typeof claim === 'object'
+        && claim !== null
+        && typeof claim['typ'] === 'string'
+        && typeof claim['val'] === 'string',
+    )
+}
+
+function isAuthenticatedPrincipal(value: unknown): value is AuthenticatedPrincipal {
+  if (typeof value !== 'object' || value === null) return false
+  const principal = value as Record<string, unknown>
+
+  return typeof principal['identityProvider'] === 'string'
+    && typeof principal['userId'] === 'string'
+    && typeof principal['userDetails'] === 'string'
+    && Array.isArray(principal['userRoles'])
+    && principal['userRoles'].every((role) => typeof role === 'string')
+    && isClaimsArray(principal['claims'])
+}
+
+export function parseHeaderPrincipal(
+  header: string | null,
+  encoding: PrincipalEncoding,
+): AuthenticatedPrincipal | null {
+  if (!header) return null
+
+  try {
+    const payload = encoding === 'base64-json'
+      ? Buffer.from(header, 'base64').toString('utf-8')
+      : header
+    const principal = JSON.parse(payload) as unknown
+    return isAuthenticatedPrincipal(principal) ? principal : null
+  } catch {
+    return null
+  }
+}
+
+export function createHeaderAuthProvider(options: {
+  headerName: string
+  encoding: PrincipalEncoding
+}): ApiAuthProvider {
+  return {
+    getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null {
+      return parseHeaderPrincipal(request.headers.get(options.headerName), options.encoding)
+    },
+  }
+}

--- a/app/api/src/auth/providers/swa.ts
+++ b/app/api/src/auth/providers/swa.ts
@@ -1,24 +1,15 @@
 import type { HttpRequest } from '@azure/functions'
 import type { AuthenticatedPrincipal } from '../types.js'
+import { createHeaderAuthProvider, parseHeaderPrincipal } from './header.js'
 
 export interface ApiAuthProvider {
   getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null
 }
 
 export function parseSwaClientPrincipal(header: string | null): AuthenticatedPrincipal | null {
-  if (!header) return null
-  try {
-    const decoded = Buffer.from(header, 'base64').toString('utf-8')
-    return JSON.parse(decoded) as AuthenticatedPrincipal
-  } catch {
-    return null
-  }
+  return parseHeaderPrincipal(header, 'base64-json')
 }
 
 export function createSwaAuthProvider(): ApiAuthProvider {
-  return {
-    getPrincipal(request: HttpRequest): AuthenticatedPrincipal | null {
-      return parseSwaClientPrincipal(request.headers.get('x-ms-client-principal'))
-    },
-  }
+  return createHeaderAuthProvider({ headerName: 'x-ms-client-principal', encoding: 'base64-json' })
 }

--- a/app/api/src/config/__tests__/runtime.test.ts
+++ b/app/api/src/config/__tests__/runtime.test.ts
@@ -26,6 +26,11 @@ describe('getApiRuntimeConfig', () => {
     expect(config.sanity.dataset).toBe('production')
     expect(config.content.documentType).toBe('blog')
     expect(config.content.draftPrefix).toBe('drafts.')
+    expect(config.auth).toEqual({
+      provider: 'swa',
+      principalHeader: 'x-ms-client-principal',
+      principalEncoding: 'base64-json',
+    })
   })
 
   it('throws when SANITY_DRAFT_PREFIX does not end with a dot', () => {
@@ -45,5 +50,34 @@ describe('getApiRuntimeConfig', () => {
     const config = getApiRuntimeConfig()
     expect(config.content.documentType).toBe('article')
     expect(config.content.titleField).toBe('headline')
+  })
+
+  it('switches auth defaults for generic header provider', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+    process.env['AUTH_PROVIDER'] = 'header'
+
+    const config = getApiRuntimeConfig()
+    expect(config.auth).toEqual({
+      provider: 'header',
+      principalHeader: 'x-authenticated-principal',
+      principalEncoding: 'json',
+    })
+  })
+
+  it('throws on invalid auth provider', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+    process.env['AUTH_PROVIDER'] = 'custom'
+
+    expect(() => getApiRuntimeConfig()).toThrow('AUTH_PROVIDER must be "swa" or "header"')
+  })
+
+  it('throws on invalid principal header name', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+    process.env['AUTH_PRINCIPAL_HEADER'] = 'x principal'
+
+    expect(() => getApiRuntimeConfig()).toThrow('AUTH_PRINCIPAL_HEADER must contain only letters, digits, and hyphens')
   })
 })

--- a/app/api/src/config/runtime.ts
+++ b/app/api/src/config/runtime.ts
@@ -13,6 +13,11 @@ export interface ApiRuntimeConfig {
     slugField: string
     publishedAtField: string
   }
+  auth: {
+    provider: 'swa' | 'header'
+    principalHeader: string
+    principalEncoding: 'base64-json' | 'json'
+  }
 }
 
 let cachedConfig: ApiRuntimeConfig | null = null
@@ -27,6 +32,38 @@ function readFieldName(value: string | undefined, fallback: string, key: string)
     throw new Error(`Invalid runtime configuration: ${key} must match /^[A-Za-z_][A-Za-z0-9_]*$/`)
   }
   return field
+}
+
+function readAuthProvider(value: string | undefined): ApiRuntimeConfig['auth']['provider'] {
+  const provider = value ?? 'swa'
+  switch (provider) {
+    case 'swa':
+    case 'header':
+      return provider
+    default:
+      throw new Error('Invalid runtime configuration: AUTH_PROVIDER must be "swa" or "header"')
+  }
+}
+
+function readPrincipalEncoding(value: string | undefined): ApiRuntimeConfig['auth']['principalEncoding'] {
+  const encoding = value ?? 'base64-json'
+  switch (encoding) {
+    case 'base64-json':
+    case 'json':
+      return encoding
+    default:
+      throw new Error(
+        'Invalid runtime configuration: AUTH_PRINCIPAL_ENCODING must be "base64-json" or "json"',
+      )
+  }
+}
+
+function readHeaderName(value: string | undefined, fallback: string, key: string): string {
+  const header = envString(value) ?? fallback
+  if (!/^[A-Za-z0-9-]+$/.test(header)) {
+    throw new Error(`Invalid runtime configuration: ${key} must contain only letters, digits, and hyphens`)
+  }
+  return header.toLowerCase()
 }
 
 export function getApiRuntimeConfig(): ApiRuntimeConfig {
@@ -48,6 +85,12 @@ export function getApiRuntimeConfig(): ApiRuntimeConfig {
     throw new Error('Invalid runtime configuration: SANITY_DRAFT_PREFIX must end with "."')
   }
 
+  const authProvider = readAuthProvider(process.env['AUTH_PROVIDER'])
+  const defaultPrincipalHeader = authProvider === 'swa'
+    ? 'x-ms-client-principal'
+    : 'x-authenticated-principal'
+  const defaultPrincipalEncoding = authProvider === 'swa' ? 'base64-json' : 'json'
+
   cachedConfig = {
     sanity: {
       projectId: projectId ?? 'unset',
@@ -66,6 +109,15 @@ export function getApiRuntimeConfig(): ApiRuntimeConfig {
         'publishedAt',
         'SANITY_PUBLISHED_AT_FIELD',
       ),
+    },
+    auth: {
+      provider: authProvider,
+      principalHeader: readHeaderName(
+        process.env['AUTH_PRINCIPAL_HEADER'],
+        defaultPrincipalHeader,
+        'AUTH_PRINCIPAL_HEADER',
+      ),
+      principalEncoding: readPrincipalEncoding(process.env['AUTH_PRINCIPAL_ENCODING'] ?? defaultPrincipalEncoding),
     },
   }
 

--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -15,6 +15,8 @@ interface ImportMetaEnv {
   readonly VITE_SANITY_SLUG_FIELD?: string
   readonly VITE_SANITY_PUBLISHED_AT_FIELD?: string
   readonly VITE_SANITY_DRAFT_PREFIX?: string
+  readonly VITE_AUTH_PROVIDER?: string
+  readonly VITE_AUTH_CURRENT_USER_PATH?: string
   readonly VITE_AUTH_LOGIN_PATH?: string
   readonly VITE_AUTH_LOGOUT_PATH?: string
   readonly VITE_AUTH_POST_LOGIN_REDIRECT_PARAM?: string

--- a/app/src/config/__tests__/runtime.test.ts
+++ b/app/src/config/__tests__/runtime.test.ts
@@ -19,6 +19,8 @@ describe('createRuntimeConfig', () => {
 
     expect(config.content.documentType).toBe('blog')
     expect(config.content.draftPrefix).toBe('drafts.')
+    expect(config.auth.provider).toBe('swa')
+    expect(config.auth.currentUserPath).toBe('/.auth/me')
     expect(config.auth.loginPath).toBe('/.auth/login/aad')
     expect(config.app.name).toBe('Earnesty')
   })
@@ -58,5 +60,16 @@ describe('createRuntimeConfig', () => {
       slugField: 'path',
       publishedAtField: 'publishedOn',
     })
+  })
+
+  it('switches the default current-user path for api auth provider', () => {
+    const config = createRuntimeConfig(makeEnv({ VITE_AUTH_PROVIDER: 'api' }))
+    expect(config.auth.currentUserPath).toBe('/api/me')
+  })
+
+  it('throws on invalid auth provider', () => {
+    expect(() => createRuntimeConfig(makeEnv({ VITE_AUTH_PROVIDER: 'custom' }))).toThrow(
+      'VITE_AUTH_PROVIDER must be "swa" or "api"',
+    )
   })
 })

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -7,6 +7,8 @@ export interface FrontendRuntimeConfig {
     aboutSummary: string
   }
   auth: {
+    provider: 'swa' | 'api'
+    currentUserPath: string
     loginPath: string
     logoutPath: string
     postLoginRedirectParam: string
@@ -56,6 +58,17 @@ function readFieldName(value: string | undefined, fallback: string, key: string)
   return field
 }
 
+function readAuthProvider(value: string | undefined): FrontendRuntimeConfig['auth']['provider'] {
+  const provider = value ?? 'swa'
+  switch (provider) {
+    case 'swa':
+    case 'api':
+      return provider
+    default:
+      throw new Error('Invalid runtime configuration: VITE_AUTH_PROVIDER must be "swa" or "api"')
+  }
+}
+
 export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
   const appName = envString(env.VITE_APP_NAME) ?? 'Earnesty'
   const introTitle = envString(env.VITE_APP_INTRO_TITLE) ?? `${appName} is your space for focused writing`
@@ -77,6 +90,9 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
     throw new Error('Invalid runtime configuration: VITE_SANITY_DRAFT_PREFIX must end with "."')
   }
 
+  const authProvider = readAuthProvider(envString(env.VITE_AUTH_PROVIDER))
+  const defaultCurrentUserPath = authProvider === 'api' ? '/api/me' : '/.auth/me'
+
   return {
     app: {
       name: appName,
@@ -86,6 +102,12 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
       aboutSummary,
     },
     auth: {
+      provider: authProvider,
+      currentUserPath: readPath(
+        envString(env.VITE_AUTH_CURRENT_USER_PATH),
+        defaultCurrentUserPath,
+        'VITE_AUTH_CURRENT_USER_PATH',
+      ),
       loginPath: readPath(envString(env.VITE_AUTH_LOGIN_PATH), '/.auth/login/aad', 'VITE_AUTH_LOGIN_PATH'),
       logoutPath: readPath(envString(env.VITE_AUTH_LOGOUT_PATH), '/.auth/logout', 'VITE_AUTH_LOGOUT_PATH'),
       postLoginRedirectParam: envString(env.VITE_AUTH_POST_LOGIN_REDIRECT_PARAM) ?? 'post_login_redirect_uri',

--- a/app/src/services/__tests__/authProvider.test.ts
+++ b/app/src/services/__tests__/authProvider.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRuntimeAuthProvider } from '../authProvider.js'
+import type { FrontendRuntimeConfig } from '../../config/runtime.js'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function makeConfig(
+  overrides: Partial<FrontendRuntimeConfig['auth']> = {},
+): FrontendRuntimeConfig {
+  return {
+    app: {
+      name: 'Earnesty',
+      introTitle: 'title',
+      introLead: 'lead',
+      introHint: 'hint',
+      aboutSummary: 'summary',
+    },
+    auth: {
+      provider: 'swa',
+      currentUserPath: '/.auth/me',
+      loginPath: '/.auth/login/aad',
+      logoutPath: '/.auth/logout',
+      postLoginRedirectParam: 'post_login_redirect_uri',
+      ...overrides,
+    },
+    content: {
+      documentType: 'blog',
+      draftPrefix: 'drafts.',
+      titleField: 'title',
+      bodyField: 'body',
+      slugField: 'slug',
+      publishedAtField: 'publishedAt',
+    },
+    sanity: {
+      projectId: 'project',
+      dataset: 'dataset',
+      apiVersion: '2024-01-01',
+      useProxy: false,
+    },
+    telemetry: {},
+  }
+}
+
+function makeResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response
+}
+
+describe('createRuntimeAuthProvider', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('reads SWA current-user envelopes by default', async () => {
+    mockFetch.mockResolvedValue(makeResponse({
+      clientPrincipal: {
+        identityProvider: 'aad',
+        userId: 'user-1',
+        userDetails: 'user@example.com',
+        userRoles: ['authenticated'],
+      },
+    }))
+
+    const provider = createRuntimeAuthProvider(makeConfig())
+    await expect(provider.getCurrentUser()).resolves.toEqual({
+      identityProvider: 'aad',
+      userId: 'user-1',
+      userDetails: 'user@example.com',
+      userRoles: ['authenticated'],
+    })
+    expect(mockFetch).toHaveBeenCalledWith('/.auth/me')
+  })
+
+  it('reads direct API principals when configured', async () => {
+    mockFetch.mockResolvedValue(makeResponse({
+      identityProvider: 'proxy',
+      userId: 'user-2',
+      userDetails: 'proxy@example.com',
+      userRoles: ['authenticated'],
+    }))
+
+    const provider = createRuntimeAuthProvider(makeConfig({
+      provider: 'api',
+      currentUserPath: '/api/me',
+    }))
+    await expect(provider.getCurrentUser()).resolves.toEqual({
+      identityProvider: 'proxy',
+      userId: 'user-2',
+      userDetails: 'proxy@example.com',
+      userRoles: ['authenticated'],
+    })
+    expect(mockFetch).toHaveBeenCalledWith('/api/me')
+  })
+
+  it('returns null for malformed current-user payloads', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ clientPrincipal: { userId: 'missing-fields' } }))
+
+    const provider = createRuntimeAuthProvider(makeConfig())
+    await expect(provider.getCurrentUser()).resolves.toBeNull()
+  })
+
+  it('builds login URLs from the configured runtime contract', () => {
+    const provider = createRuntimeAuthProvider(makeConfig({
+      loginPath: '/auth/login',
+      postLoginRedirectParam: 'redirectTo',
+    }))
+
+    expect(provider.getLoginUrl('/editor?doc=1')).toBe('/auth/login?redirectTo=%2Feditor%3Fdoc%3D1')
+  })
+})

--- a/app/src/services/authProvider.ts
+++ b/app/src/services/authProvider.ts
@@ -1,4 +1,4 @@
-import { runtimeConfig } from '../config/runtime'
+import { runtimeConfig, type FrontendRuntimeConfig } from '../config/runtime'
 
 export interface AuthUser {
   identityProvider: string
@@ -13,31 +13,63 @@ export interface AuthProvider {
   getLogoutUrl(): string
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function parseAuthUser(value: unknown): AuthUser | null {
+  if (!isRecord(value)) return null
+  if (
+    typeof value['identityProvider'] !== 'string'
+    || typeof value['userId'] !== 'string'
+    || typeof value['userDetails'] !== 'string'
+    || !isStringArray(value['userRoles'])
+  ) {
+    return null
+  }
+
+  return {
+    identityProvider: value['identityProvider'],
+    userId: value['userId'],
+    userDetails: value['userDetails'],
+    userRoles: value['userRoles'],
+  }
+}
+
+function readCurrentUser(payload: unknown, provider: FrontendRuntimeConfig['auth']['provider']): AuthUser | null {
+  if (provider === 'api') return parseAuthUser(payload)
+  if (!isRecord(payload)) return null
+  return parseAuthUser(payload['clientPrincipal'])
+}
+
 function normalizeRedirectPath(path: string): string {
   if (!path.startsWith('/') || path.startsWith('//')) return '/'
   return path
 }
 
-export function createSwaAuthProvider(): AuthProvider {
+export function createRuntimeAuthProvider(config: FrontendRuntimeConfig = runtimeConfig): AuthProvider {
   return {
     async getCurrentUser(): Promise<AuthUser | null> {
       try {
-        const res = await fetch('/.auth/me')
+        const res = await fetch(config.auth.currentUserPath)
         if (!res.ok) return null
-        const data = (await res.json()) as { clientPrincipal: AuthUser | null }
-        return data.clientPrincipal
+        return readCurrentUser(await res.json(), config.auth.provider)
       } catch {
         return null
       }
     },
     getLoginUrl(postLoginRedirectPath: string): string {
       const redirectPath = normalizeRedirectPath(postLoginRedirectPath)
-      return `${runtimeConfig.auth.loginPath}?${runtimeConfig.auth.postLoginRedirectParam}=${encodeURIComponent(redirectPath)}`
+      return `${config.auth.loginPath}?${config.auth.postLoginRedirectParam}=${encodeURIComponent(redirectPath)}`
     },
     getLogoutUrl(): string {
-      return runtimeConfig.auth.logoutPath
+      return config.auth.logoutPath
     },
   }
 }
 
-export const authProvider: AuthProvider = createSwaAuthProvider()
+export const authProvider: AuthProvider = createRuntimeAuthProvider()


### PR DESCRIPTION
The app and API previously assumed Azure Static Web Apps in core logic -- hardcoded `/.auth/me` for current-user discovery, `x-ms-client-principal` for server-side auth, and the SWA base64-JSON envelope format. This makes it unnecessarily hard to deploy the app on any other host without patching code. This PR introduces an explicit hosting contract that keeps SWA as the default adapter path while allowing alternative hosts to configure their own auth surfaces without code changes.

## What changed

**Frontend**

- `FrontendRuntimeConfig.auth` gains two new fields: `provider` (`'swa' | 'api'`) and `currentUserPath`. Both are controlled by the new `VITE_AUTH_PROVIDER` and `VITE_AUTH_CURRENT_USER_PATH` env vars, with sensible defaults (`swa` / `/.auth/me`).
- `createSwaAuthProvider()` is renamed `createRuntimeAuthProvider()`. It now fetches the configured `currentUserPath` and parses the response according to the selected provider convention -- SWA's `{ clientPrincipal: ... }` envelope or a direct principal object for `api` mode.
- New test file `authProvider.test.ts` covers both provider modes and malformed-payload handling.

**API**

- `ApiRuntimeConfig` gains an `auth` section (`provider`, `principalHeader`, `principalEncoding`) driven by three new env vars: `AUTH_PROVIDER`, `AUTH_PRINCIPAL_HEADER`, `AUTH_PRINCIPAL_ENCODING`.
- Principal-parsing logic is extracted into `app/api/src/auth/providers/header.ts`. The SWA provider delegates to it. `getApiAuthBoundary()` now selects the right provider from runtime config rather than hardwiring the SWA header name.
- Validation is fail-fast and consistent with the existing runtime-config pattern (invalid values throw explicit errors at startup).

**Docs / config**

- `README.md` gains a "Portability boundary" subsection that distinguishes portable runtime requirements from Azure-only surfaces (`staticwebapp.config.json`, Azure Functions hosting, `infra/**`, deploy workflows).
- Both new frontend and API env vars are documented in the runtime configuration tables.
- `.env.example` updated with the new optional vars.

## Trade-offs / things to note

- Azure SWA remains the default everywhere -- no existing deployment needs to change anything.
- `parseSwaClientPrincipal` is kept as a named export for backwards compatibility with existing tests and any external callers.
- The `isAuthenticatedPrincipal` guard in the header provider validates the full principal shape; SWA previously used an unchecked cast, so this is a minor strictness improvement.

Fixes: #146