### PR TITLE
test: apply runtime-config test and docs cross-cutting updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,6 +69,8 @@ cd app && npm run test:integration
 
 Integration tests use a unique timestamp-based document ID per run and always clean up in `afterAll`, even on failure.
 
+When creating or updating test fixtures, prefer deriving document type, field names, and draft prefix from runtime configuration helpers instead of hardcoding `blog`, `title`, `body`, or `drafts.`. Keep hardcoded values only in tests that explicitly validate default fallback behavior.
+
 In GitHub Actions, integration tests run in the `test-integration` job under the `dev` environment, which holds the Sanity development dataset credentials. The `build` job depends on this job passing.
 
 Run the full test suite before committing whenever business logic or Sanity interactions are changed:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A minimal, focused writing environment built with [Vue 3](https://vuejs.org) and
    VITE_SANITY_SLUG_FIELD=slug
    VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
    VITE_SANITY_DRAFT_PREFIX=drafts.
+   VITE_AUTH_PROVIDER=swa
+   VITE_AUTH_CURRENT_USER_PATH=/.auth/me
    VITE_AUTH_LOGIN_PATH=/.auth/login/aad
    VITE_AUTH_LOGOUT_PATH=/.auth/logout
    VITE_AUTH_POST_LOGIN_REDIRECT_PARAM=post_login_redirect_uri
@@ -160,8 +162,26 @@ Configure the following secrets on **each environment** (not at repository level
 | `SANITY_PROJECT_ID` | Sanity project ID (server-side, for API functions) |
 | `SANITY_DATASET` | Sanity dataset name (server-side, for API functions) |
 
+Optional runtime overrides are supported for reusable deployments. Configure these as **Azure Static Web App application settings** if you need non-default schema/auth mapping:
+
+| Optional SWA App Setting | Default |
+|---|---|
+| `SANITY_DOCUMENT_TYPE` | `blog` |
+| `SANITY_TITLE_FIELD` | `title` |
+| `SANITY_BODY_FIELD` | `body` |
+| `SANITY_SLUG_FIELD` | `slug` |
+| `SANITY_PUBLISHED_AT_FIELD` | `publishedAt` |
+| `SANITY_DRAFT_PREFIX` | `drafts.` |
+| `AUTH_PROVIDER` | `swa` |
+| `AUTH_PRINCIPAL_HEADER` | `x-ms-client-principal` for `swa`, `x-authenticated-principal` for `header` |
+| `AUTH_PRINCIPAL_ENCODING` | `base64-json` for `swa`, `json` for `header` |
+
 > [!TIP]
 > `VITE_SANITY_PROJECT_ID` is typically the same across environments. `VITE_SANITY_DATASET` and `VITE_SANITY_TOKEN` should differ — use a read/write token scoped to the appropriate dataset in each environment.
+
+## Migration checklist
+
+Migration guidance for moving from hardcoded schema/auth assumptions to runtime-config values is maintained in issue **#147** so operators can track checklist updates in one place.
 
 ## Entra ID App Registration
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -10,6 +10,7 @@ VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
 VITE_SANITY_DRAFT_PREFIX=drafts.
 # Optional auth provider/runtime contract
 VITE_AUTH_PROVIDER=swa
+# Use /.auth/me for SWA provider, or /api/me for api provider.
 VITE_AUTH_CURRENT_USER_PATH=/.auth/me
 # Optional auth route mapping
 VITE_AUTH_LOGIN_PATH=/.auth/login/aad

--- a/app/api/src/__tests__/document.integration.test.ts
+++ b/app/api/src/__tests__/document.integration.test.ts
@@ -10,14 +10,18 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { getSanityClient } from '../shared.js'
+import { getApiRuntimeConfig } from '../config/runtime.js'
 
 const hasCredentials = Boolean(
   process.env['SANITY_PROJECT_ID'] && process.env['SANITY_TOKEN'],
 )
 
+const runtimeConfig = getApiRuntimeConfig()
+const contentConfig = runtimeConfig.content
+
 // Each integration run gets a unique document ID so parallel runs never clash.
 const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
-const DRAFT_ID = `drafts.integration-${RUN_ID}`
+const DRAFT_ID = `${contentConfig.draftPrefix}integration-${RUN_ID}`
 const PUBLISHED_ID = `integration-${RUN_ID}`
 
 const TEST_BLOCKS = [
@@ -42,21 +46,21 @@ describe.skipIf(!hasCredentials)('Integration: document lifecycle (mirrors Azure
 
   // ── createDraft ─────────────────────────────────────────────────────────────
   // Mirrors the operation in createDraft.ts:
-  //   getSanityClient().create({ _id, _type: 'blog', title, slug })
+  //   getSanityClient().create({ _id, _type: config.documentType, [titleField], [slugField] })
 
   describe('createDraft operation', () => {
     it('creates a draft document in Sanity', async () => {
       const client = getSanityClient()
       const doc = await client.create({
         _id: DRAFT_ID,
-        _type: 'blog',
-        title: 'Integration Test Draft',
-        slug: { _type: 'slug', current: `integration-test-${RUN_ID}` },
+        _type: contentConfig.documentType,
+        [contentConfig.titleField]: 'Integration Test Draft',
+        [contentConfig.slugField]: { _type: 'slug', current: `integration-test-${RUN_ID}` },
       })
 
       expect(doc._id).toBe(DRAFT_ID)
-      expect(doc._type).toBe('blog')
-      expect(doc.title).toBe('Integration Test Draft')
+      expect(doc._type).toBe(contentConfig.documentType)
+      expect((doc as Record<string, unknown>)[contentConfig.titleField]).toBe('Integration Test Draft')
     })
 
     it('the created document is retrievable immediately (useCdn: false)', async () => {
@@ -68,14 +72,14 @@ describe.skipIf(!hasCredentials)('Integration: document lifecycle (mirrors Azure
 
   // ── saveDocument ─────────────────────────────────────────────────────────────
   // Mirrors the operation in saveDocument.ts:
-  //   getSanityClient().patch(id).set({ body, title }).commit()
+  //   getSanityClient().patch(id).set({ [bodyField], [titleField] }).commit()
 
   describe('saveDocument operation', () => {
     it('patches the draft with PortableText blocks', async () => {
       const client = getSanityClient()
       const result = await client
         .patch(DRAFT_ID)
-        .set({ body: TEST_BLOCKS })
+        .set({ [contentConfig.bodyField]: TEST_BLOCKS })
         .commit()
 
       expect(result._id).toBe(DRAFT_ID)
@@ -85,7 +89,7 @@ describe.skipIf(!hasCredentials)('Integration: document lifecycle (mirrors Azure
       const client = getSanityClient()
       const result = await client
         .patch(DRAFT_ID)
-        .set({ title: 'Updated Integration Title' })
+        .set({ [contentConfig.titleField]: 'Updated Integration Title' })
         .commit()
 
       expect(result._id).toBe(DRAFT_ID)
@@ -93,9 +97,9 @@ describe.skipIf(!hasCredentials)('Integration: document lifecycle (mirrors Azure
 
     it('persists patched content when the document is fetched back', async () => {
       const doc = await getSanityClient().getDocument(DRAFT_ID) as Record<string, unknown>
-      expect(doc?.['title']).toBe('Updated Integration Title')
-      expect(Array.isArray(doc?.['body'])).toBe(true)
-      const body = doc?.['body'] as Array<Record<string, unknown>>
+      expect(doc?.[contentConfig.titleField]).toBe('Updated Integration Title')
+      expect(Array.isArray(doc?.[contentConfig.bodyField])).toBe(true)
+      const body = doc?.[contentConfig.bodyField] as Array<Record<string, unknown>>
       expect(body[0]?.['_type']).toBe('block')
     })
   })
@@ -129,8 +133,8 @@ describe.skipIf(!hasCredentials)('Integration: document lifecycle (mirrors Azure
     it('published document exists with the correct content after the transaction', async () => {
       const published = await getSanityClient().getDocument(PUBLISHED_ID) as Record<string, unknown>
       expect(published?.['_id']).toBe(PUBLISHED_ID)
-      expect(published?.['_type']).toBe('blog')
-      expect(published?.['title']).toBe('Updated Integration Title')
+      expect(published?.['_type']).toBe(contentConfig.documentType)
+      expect(published?.[contentConfig.titleField]).toBe('Updated Integration Title')
       // _rev must not be the original draft's _rev
       expect(published?.['_rev']).toBeDefined()
     })

--- a/app/src/services/__tests__/api.test.ts
+++ b/app/src/services/__tests__/api.test.ts
@@ -138,7 +138,7 @@ describe('apiCreateDraft', () => {
   })
 
   it('sends a POST request to the documents endpoint', async () => {
-    const newDoc = { _id: 'drafts.uuid', _type: 'blog', title: 'New Post', _createdAt: '', _updatedAt: '' }
+    const newDoc = { _id: 'drafts.uuid', _type: 'article', title: 'New Post', _createdAt: '', _updatedAt: '' }
     mockFetch.mockResolvedValue(makeResponse(201, newDoc))
     await apiCreateDraft('New Post', 'new-post')
 
@@ -149,7 +149,7 @@ describe('apiCreateDraft', () => {
   })
 
   it('sends title and slug in the request body', async () => {
-    const newDoc = { _id: 'drafts.uuid', _type: 'blog', title: 'New Post', _createdAt: '', _updatedAt: '' }
+    const newDoc = { _id: 'drafts.uuid', _type: 'article', title: 'New Post', _createdAt: '', _updatedAt: '' }
     mockFetch.mockResolvedValue(makeResponse(201, newDoc))
     await apiCreateDraft('New Post', 'new-post')
 
@@ -159,7 +159,7 @@ describe('apiCreateDraft', () => {
   })
 
   it('returns the created document', async () => {
-    const newDoc = { _id: 'drafts.uuid', _type: 'blog', title: 'New Post', _createdAt: '', _updatedAt: '' }
+    const newDoc = { _id: 'drafts.uuid', _type: 'article', title: 'New Post', _createdAt: '', _updatedAt: '' }
     mockFetch.mockResolvedValue(makeResponse(201, newDoc))
 
     const result = await apiCreateDraft('New Post', 'new-post')

--- a/app/src/services/__tests__/sanity.integration.test.ts
+++ b/app/src/services/__tests__/sanity.integration.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { createClient } from '@sanity/client'
 import { fetchDocuments, fetchDocument } from '../sanity.js'
+import { runtimeConfig } from '../../config/runtime.js'
 
 const projectId = import.meta.env.VITE_SANITY_PROJECT_ID as string | undefined
 const dataset = (import.meta.env.VITE_SANITY_DATASET as string | undefined) ?? 'production'
@@ -25,6 +26,7 @@ const dataset = (import.meta.env.VITE_SANITY_DATASET as string | undefined) ?? '
 const adminToken = process.env['SANITY_TOKEN']
 
 const hasCredentials = Boolean(projectId && adminToken)
+const contentConfig = runtimeConfig.content
 
 const RUN_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
 // Use a published (non-draft) ID so the GROQ query in fetchDocuments finds it.
@@ -32,21 +34,24 @@ const TEST_DOC_ID = `integration-fe-${RUN_ID}`
 
 describe.skipIf(!hasCredentials)('Integration: Sanity fetch functions', () => {
   // Admin client used only for test fixture setup and teardown.
-  const adminClient = createClient({
-    projectId,
-    dataset,
-    apiVersion: '2024-01-01',
-    token: adminToken,
-    useCdn: false,
-  })
+  const adminClient = hasCredentials
+    ? createClient({
+      projectId: projectId!,
+      dataset,
+      apiVersion: '2024-01-01',
+      token: adminToken,
+      useCdn: false,
+    })
+    : null
 
   beforeAll(async () => {
+    if (!adminClient) return
     await adminClient.create({
       _id: TEST_DOC_ID,
-      _type: 'blog',
-      title: 'Integration Fetch Test',
-      slug: { _type: 'slug', current: `integration-fe-${RUN_ID}` },
-      body: [
+      _type: contentConfig.documentType,
+      [contentConfig.titleField]: 'Integration Fetch Test',
+      [contentConfig.slugField]: { _type: 'slug', current: `integration-fe-${RUN_ID}` },
+      [contentConfig.bodyField]: [
         {
           _key: 'b1',
           _type: 'block',
@@ -59,6 +64,7 @@ describe.skipIf(!hasCredentials)('Integration: Sanity fetch functions', () => {
   })
 
   afterAll(async () => {
+    if (!adminClient) return
     await adminClient.delete(TEST_DOC_ID).catch(() => {})
   })
 


### PR DESCRIPTION
This closes the remaining hardcoded assumptions in tests and guidance after the runtime-contract refactor, so schema/auth customization is consistently documented and reflected in fixtures.

## What changed
- Updated API integration fixtures to derive `documentType`, field names, and `draftPrefix` from API runtime config instead of hardcoded `blog/title/body/drafts.` values.
- Updated frontend Sanity integration fixtures to derive schema mapping from frontend runtime config and avoid initializing a Sanity client when credentials are absent.
- Relaxed frontend API create-draft fixtures to avoid asserting a fixed backend `_type` value.
- Expanded docs and examples for reusable runtime configuration:
  - Added frontend auth provider/current-user env vars to local setup examples.
  - Added optional API runtime override table for schema/auth mapping in deployment guidance.
  - Added explicit testing guidance to prefer config-derived fixtures over hardcoded defaults.
- Posted migration checklist guidance directly on issue #147 as requested.

## Notes for reviewers
- Integration test behavior is unchanged; fixtures now follow the same runtime contract used by production code.
- The migration checklist is intentionally tracked in the issue thread to keep operational rollout steps centralized.

Fixes: #147