### PR TITLE
feat: decouple product-named storage keys and auth provider label

### DIFF
--- a/app/src/components/UserModal.vue
+++ b/app/src/components/UserModal.vue
@@ -7,7 +7,6 @@ defineProps<{ user: AuthUser }>()
 const emit = defineEmits<{ close: []; logout: [] }>()
 
 function providerLabel(identityProvider: string): string {
-  if (identityProvider === 'aad') return 'Microsoft'
   return identityProvider.charAt(0).toUpperCase() + identityProvider.slice(1)
 }
 </script>

--- a/app/src/config/__tests__/runtime.test.ts
+++ b/app/src/config/__tests__/runtime.test.ts
@@ -23,6 +23,7 @@ describe('createRuntimeConfig', () => {
     expect(config.auth.currentUserPath).toBe('/.auth/me')
     expect(config.auth.loginPath).toBe('/.auth/login/aad')
     expect(config.app.name).toBe('Earnesty')
+    expect(config.app.storageNamespace).toBe('earnesty')
   })
 
   it('throws when VITE_SANITY_PROJECT_ID is missing outside test mode', () => {
@@ -70,6 +71,22 @@ describe('createRuntimeConfig', () => {
   it('throws on invalid auth provider', () => {
     expect(() => createRuntimeConfig(makeEnv({ VITE_AUTH_PROVIDER: 'custom' }))).toThrow(
       'VITE_AUTH_PROVIDER must be "swa" or "api"',
+    )
+  })
+
+  it('derives storageNamespace from app name when unset', () => {
+    const config = createRuntimeConfig(makeEnv({ VITE_APP_NAME: 'My App' }))
+    expect(config.app.storageNamespace).toBe('my-app')
+  })
+
+  it('accepts a custom VITE_APP_STORAGE_NAMESPACE', () => {
+    const config = createRuntimeConfig(makeEnv({ VITE_APP_STORAGE_NAMESPACE: 'my-custom-ns' }))
+    expect(config.app.storageNamespace).toBe('my-custom-ns')
+  })
+
+  it('throws on an invalid VITE_APP_STORAGE_NAMESPACE', () => {
+    expect(() => createRuntimeConfig(makeEnv({ VITE_APP_STORAGE_NAMESPACE: 'My NS!' }))).toThrow(
+      'VITE_APP_STORAGE_NAMESPACE',
     )
   })
 })

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -1,6 +1,7 @@
 export interface FrontendRuntimeConfig {
   app: {
     name: string
+    storageNamespace: string
     introTitle: string
     introLead: string
     introHint: string
@@ -69,8 +70,20 @@ function readAuthProvider(value: string | undefined): FrontendRuntimeConfig['aut
   }
 }
 
+function readStorageNamespace(value: string | undefined, fallback: string): string {
+  const ns = value ?? fallback.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(ns)) {
+    throw new Error(
+      'Invalid runtime configuration: VITE_APP_STORAGE_NAMESPACE must start with a letter or digit and contain only lowercase letters, digits, and hyphens',
+    )
+  }
+  return ns
+}
+
+
 export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
   const appName = envString(env.VITE_APP_NAME) ?? 'Earnesty'
+  const storageNamespace = readStorageNamespace(envString(env.VITE_APP_STORAGE_NAMESPACE), appName)
   const introTitle = envString(env.VITE_APP_INTRO_TITLE) ?? `${appName} is your space for focused writing`
   const introLead = envString(env.VITE_APP_INTRO_LEAD)
     ?? 'No distractions. No formatting toolbars. Just you and the blank page. All vibes. No QA.'
@@ -96,6 +109,7 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
   return {
     app: {
       name: appName,
+      storageNamespace,
       introTitle,
       introLead,
       introHint,

--- a/app/src/stores/editor.ts
+++ b/app/src/stores/editor.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, shallowRef } from 'vue'
 import type { ContentDocument } from '../services/sanity'
 import { INTRO_HTML } from '../constants'
+import { runtimeConfig } from '../config/runtime'
 
 export interface DocumentMeta {
   title: string
@@ -10,8 +11,9 @@ export interface DocumentMeta {
   tags: string[]
 }
 
-const SESSION_KEY = 'earnesty-session'
-export const CONTENT_KEY = 'earnesty-content'
+const ns = runtimeConfig.app.storageNamespace
+const SESSION_KEY = `${ns}-session`
+export const CONTENT_KEY = `${ns}-content`
 
 interface PersistedSession {
   activeDocument: ContentDocument | null

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
+import { runtimeConfig } from '../config/runtime'
 
 export type Theme = 'light' | 'dark' | 'whimsical'
 export type Font = 'serif' | 'sans-serif' | 'comic-sans'
@@ -84,7 +85,7 @@ function clearWhimsicalPalette() {
   }
 }
 
-const STORAGE_KEY = 'ernesty:settings'
+const STORAGE_KEY = `${runtimeConfig.app.storageNamespace}:settings`
 
 interface Settings {
   theme: Theme
@@ -128,7 +129,7 @@ export const useSettingsStore = defineStore('settings', () => {
   let fontBeforeWhimsical: Font | null = null
 
   // Restore saved pre-whimsical font on init
-  const FONT_BEFORE_KEY = 'ernesty:fontBeforeWhimsical'
+  const FONT_BEFORE_KEY = `${runtimeConfig.app.storageNamespace}:fontBeforeWhimsical`
   if (settings.value.theme === 'whimsical') {
     const saved = localStorage.getItem(FONT_BEFORE_KEY)
     if (saved) fontBeforeWhimsical = saved as Font


### PR DESCRIPTION
Closes #142

## Summary

This is the final fix for the coupling inventory tracked in #142. Issues #143–#147 addressed the major boundaries (runtime config, auth abstraction, schema mapping, hosting decoupling, and cross-cutting tests). Two **Medium**-severity and one **Low**-severity coupling points from the original inventory remained:

| File | Hardcoded value | Severity |
|---|---|---|
| `app/src/stores/editor.ts` | `'earnesty-session'` / `'earnesty-content'` storage keys | Medium |
| `app/src/stores/settings.ts` | `'ernesty:settings'` / `'ernesty:fontBeforeWhimsical'` (with typo) | Medium |
| `app/src/components/UserModal.vue` | `aad` → `'Microsoft'` provider label | Low |

## Changes

- **`app/src/config/runtime.ts`** — adds `app.storageNamespace` to `FrontendRuntimeConfig`, configurable via `VITE_APP_STORAGE_NAMESPACE`; defaults to a lowercase, hyphen-normalised form of the app name (e.g. `'Earnesty'` → `'earnesty'`)
- **`app/src/stores/editor.ts`** — derives `SESSION_KEY` and `CONTENT_KEY` from `runtimeConfig.app.storageNamespace`
- **`app/src/stores/settings.ts`** — derives both storage keys from `runtimeConfig.app.storageNamespace` (also fixes the `ernesty` typo as a side effect)
- **`app/src/components/UserModal.vue`** — removes the `aad` → `'Microsoft'` special case; provider name is capitalised generically
- **`app/src/config/__tests__/runtime.test.ts`** — adds test cases for `storageNamespace` default, custom override, and validation error

## Testing

All 86 frontend tests pass. ESLint and type check are clean.