### PR TITLE
fix: allow absent or null claims in SWA principal validation

### DIFF
--- a/app/api/src/__tests__/shared.test.ts
+++ b/app/api/src/__tests__/shared.test.ts
@@ -16,13 +16,48 @@ describe('parseSwaClientPrincipal', () => {
     expect(parseSwaClientPrincipal(invalid)).toBeNull()
   })
 
-  it('parses a valid base64-encoded principal', () => {
+  it('parses a valid base64-encoded principal with claims', () => {
     const principal = {
       identityProvider: 'aad',
       userId: 'user-123',
       userDetails: 'test@example.com',
       userRoles: ['authenticated', 'anonymous'],
       claims: [{ typ: 'name', val: 'Test User' }],
+    }
+    const encoded = Buffer.from(JSON.stringify(principal)).toString('base64')
+    expect(parseSwaClientPrincipal(encoded)).toEqual(principal)
+  })
+
+  it('parses a valid base64-encoded principal without claims', () => {
+    const principal = {
+      identityProvider: 'aad',
+      userId: 'user-123',
+      userDetails: 'test@example.com',
+      userRoles: ['authenticated', 'anonymous'],
+    }
+    const encoded = Buffer.from(JSON.stringify(principal)).toString('base64')
+    expect(parseSwaClientPrincipal(encoded)).toEqual(principal)
+  })
+
+  it('parses a valid base64-encoded principal with null claims', () => {
+    const raw = {
+      identityProvider: 'aad',
+      userId: 'user-123',
+      userDetails: 'test@example.com',
+      userRoles: ['authenticated', 'anonymous'],
+      claims: null,
+    }
+    const encoded = Buffer.from(JSON.stringify(raw)).toString('base64')
+    expect(parseSwaClientPrincipal(encoded)).toEqual(raw)
+  })
+
+  it('parses a valid base64-encoded principal with empty claims array', () => {
+    const principal = {
+      identityProvider: 'aad',
+      userId: 'user-123',
+      userDetails: 'test@example.com',
+      userRoles: ['authenticated', 'anonymous'],
+      claims: [],
     }
     const encoded = Buffer.from(JSON.stringify(principal)).toString('base64')
     expect(parseSwaClientPrincipal(encoded)).toEqual(principal)

--- a/app/api/src/auth/providers/header.ts
+++ b/app/api/src/auth/providers/header.ts
@@ -4,7 +4,7 @@ import type { ApiAuthProvider } from './swa.js'
 
 export type PrincipalEncoding = 'base64-json' | 'json'
 
-function isClaimsArray(value: unknown): value is AuthenticatedPrincipal['claims'] {
+function isClaimsArray(value: unknown): value is NonNullable<AuthenticatedPrincipal['claims']> {
   return Array.isArray(value)
     && value.every(
       (claim) => typeof claim === 'object'
@@ -23,7 +23,7 @@ function isAuthenticatedPrincipal(value: unknown): value is AuthenticatedPrincip
     && typeof principal['userDetails'] === 'string'
     && Array.isArray(principal['userRoles'])
     && principal['userRoles'].every((role) => typeof role === 'string')
-    && isClaimsArray(principal['claims'])
+    && (principal['claims'] == null || isClaimsArray(principal['claims']))
 }
 
 export function parseHeaderPrincipal(

--- a/app/api/src/auth/types.ts
+++ b/app/api/src/auth/types.ts
@@ -3,5 +3,5 @@ export interface AuthenticatedPrincipal {
   userId: string
   userDetails: string
   userRoles: string[]
-  claims: { typ: string; val: string }[]
+  claims?: { typ: string; val: string }[]
 }

--- a/app/src/composables/useBlogDocuments.ts
+++ b/app/src/composables/useBlogDocuments.ts
@@ -1,12 +1,14 @@
 import { ref, onMounted } from 'vue'
 import type { ContentDocument } from '../services/sanity'
 import { apiListDocuments, AuthError } from '../services/api'
+import { useAuthStore } from '../stores/auth'
 
 export function useDocuments() {
   const documents = ref<ContentDocument[]>([])
   const loading = ref(true)
   const error = ref<string | null>(null)
   const isAuthError = ref(false)
+  const auth = useAuthStore()
 
   onMounted(async () => {
     try {
@@ -16,6 +18,7 @@ export function useDocuments() {
       if (e instanceof AuthError) {
         isAuthError.value = true
         error.value = 'Your session has expired. Please sign in again.'
+        auth.invalidateSession()
       } else {
         const msg = e instanceof Error ? e.message : String(e)
         error.value = `Could not load documents: ${msg}`

--- a/app/src/stores/auth.ts
+++ b/app/src/stores/auth.ts
@@ -20,6 +20,10 @@ export const useAuthStore = defineStore('auth', () => {
     loading.value = false
   }
 
+  function invalidateSession() {
+    user.value = null
+  }
+
   function login() {
     window.location.href = authProvider.getLoginUrl('/')
   }
@@ -28,5 +32,5 @@ export const useAuthStore = defineStore('auth', () => {
     window.location.href = authProvider.getLogoutUrl()
   }
 
-  return { user, loading, isAuthenticated, initialize, login, logout }
+  return { user, loading, isAuthenticated, initialize, invalidateSession, login, logout }
 })


### PR DESCRIPTION
## Problem

Two related bugs after the recent auth refactor:

1. **API always returned 401 for authenticated users in production.** The `isAuthenticatedPrincipal` validator required `claims` to be a valid `{typ, val}[]` array. Azure SWA may omit the `claims` field (or set it to `null`) in the `x-ms-client-principal` header when no claim mapping is configured. This caused the validation to silently reject every principal → 401 on all API calls.

2. **'Sign in' button in the session-expired UI appeared to do nothing.** Because `/.auth/me` doesn't validate `claims`, the user's SWA session still looked valid and the user icon stayed signed-in. Clicking 'Sign in' navigated to login, but with a valid SWA session the user was immediately redirected back — looking like nothing happened.

## Fix

- `AuthenticatedPrincipal.claims` is now optional — validator accepts `undefined` and `null`
- `invalidateSession()` added to the auth store: clears `user` so the UI reflects the expired state immediately
- `useBlogDocuments` calls `auth.invalidateSession()` on `AuthError` so the user icon switches to 'Sign in' and the button works correctly

## Tests

- New cases: principal without `claims`, with `claims: null`, with `claims: []`
- All existing tests pass