### PR TITLE
fix: open unpublished drafts from open document

### DIFF
--- a/app/api/src/__tests__/getDocument.test.ts
+++ b/app/api/src/__tests__/getDocument.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import type { HttpRequest, HttpResponseInit } from '@azure/functions'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+import { clearApiRuntimeConfigCache } from '../config/runtime.js'
+
+const { getHandler, setHandler } = vi.hoisted(() => {
+  let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
+  return {
+    getHandler: () => _handler!,
+    setHandler: (h: (req: HttpRequest) => Promise<HttpResponseInit>) => {
+      _handler = h
+    },
+  }
+})
+
+vi.mock('@azure/functions', () => ({
+  app: {
+    http: (_name: string, config: { handler: (req: HttpRequest) => Promise<HttpResponseInit> }) => {
+      setHandler(config.handler)
+    },
+  },
+}))
+
+vi.mock('../shared.js', () => ({
+  getSanityClient: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
+}))
+
+beforeAll(async () => {
+  await import('../functions/getDocument.js')
+})
+
+const VALID_PRINCIPAL = {
+  identityProvider: 'aad',
+  userId: 'user-123',
+  userDetails: 'test@example.com',
+  userRoles: ['authenticated'],
+  claims: [],
+}
+
+function makeRequest(options?: { authenticated?: boolean; id?: string }): HttpRequest {
+  return {
+    headers: {
+      get: (name: string) =>
+        name === 'x-ms-client-principal' ? ((options?.authenticated ?? true) ? 'header' : null) : null,
+    },
+    params: options?.id ? { id: options.id } : {},
+  } as unknown as HttpRequest
+}
+
+describe('getDocument handler', () => {
+  beforeEach(() => {
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
+    const res = await getHandler()(makeRequest({ authenticated: false }))
+    expect(res.status).toBe(401)
+    expect(res.jsonBody).toEqual({ error: 'Not authenticated' })
+  })
+
+  it('returns 400 when document ID is missing', async () => {
+    const res = await getHandler()(makeRequest({ id: '' }))
+    expect(res.status).toBe(400)
+    expect(res.jsonBody).toEqual({ error: 'Missing document ID' })
+  })
+
+  it('returns 200 with the fetched document', async () => {
+    const doc = {
+      _id: 'drafts.abc',
+      _createdAt: '2024-01-01',
+      _updatedAt: '2024-01-02',
+      publishedAt: null,
+      title: 'Draft',
+      body: [],
+    }
+    const fetch = vi.fn().mockResolvedValue(doc)
+    vi.mocked(getSanityClient).mockReturnValue({ fetch } as any)
+
+    const res = await getHandler()(makeRequest({ id: 'drafts.abc' }))
+    expect(res.status).toBe(200)
+    expect(res.jsonBody).toEqual(doc)
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('_id == $id'), { id: 'drafts.abc' })
+  })
+
+  it('returns 200 with null when document does not exist', async () => {
+    const fetch = vi.fn().mockResolvedValue(null)
+    vi.mocked(getSanityClient).mockReturnValue({ fetch } as any)
+
+    const res = await getHandler()(makeRequest({ id: 'missing-id' }))
+    expect(res.status).toBe(200)
+    expect(res.jsonBody).toBeNull()
+  })
+
+  it('returns 502 when Sanity fetch throws', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('GROQ error'))
+    vi.mocked(getSanityClient).mockReturnValue({ fetch } as any)
+
+    const res = await getHandler()(makeRequest({ id: 'drafts.abc' }))
+    expect(res.status).toBe(502)
+    expect(res.jsonBody).toEqual({ error: 'Failed to fetch document' })
+  })
+})
+
+describe('getDocument handler – custom schema mapping', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      SANITY_DOCUMENT_TYPE: 'article',
+      SANITY_TITLE_FIELD: 'headline',
+      SANITY_BODY_FIELD: 'content',
+      SANITY_PUBLISHED_AT_FIELD: 'publishedOn',
+    }
+    clearApiRuntimeConfigCache()
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    clearApiRuntimeConfigCache()
+  })
+
+  it('uses configured schema fields in query projection', async () => {
+    const fetch = vi.fn().mockResolvedValue(null)
+    vi.mocked(getSanityClient).mockReturnValue({ fetch } as any)
+
+    await getHandler()(makeRequest({ id: 'drafts.abc' }))
+    const query = fetch.mock.calls[0][0] as string
+    expect(query).toContain('_type == "article"')
+    expect(query).toContain('"title": headline')
+    expect(query).toContain('"publishedAt": publishedOn')
+    expect(query).toContain('"body": content')
+  })
+})

--- a/app/api/src/functions/getDocument.ts
+++ b/app/api/src/functions/getDocument.ts
@@ -1,0 +1,43 @@
+import {
+  app,
+  type HttpRequest,
+  type HttpResponseInit,
+} from '@azure/functions'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+import { getApiRuntimeConfig } from '../config/runtime.js'
+
+app.http('getDocument', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'sanity/documents/{id}',
+  handler: async (
+    request: HttpRequest,
+  ): Promise<HttpResponseInit> => {
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
+
+    const id = request.params['id']
+    if (!id) {
+      return { status: 400, jsonBody: { error: 'Missing document ID' } }
+    }
+
+    try {
+      const config = getApiRuntimeConfig()
+      const doc = await getSanityClient().fetch(
+        `*[_type == "${config.content.documentType}" && _id == $id][0]{
+          _id,
+          _createdAt,
+          _updatedAt,
+          "publishedAt": ${config.content.publishedAtField},
+          "title": ${config.content.titleField},
+          "body": ${config.content.bodyField}
+        }`,
+        { id },
+      )
+      return { status: 200, jsonBody: doc ?? null }
+    } catch (err) {
+      console.error('[getDocument]', err)
+      return { status: 502, jsonBody: { error: 'Failed to fetch document' } }
+    }
+  },
+})

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -9,7 +9,7 @@ import PublishModal from './components/PublishModal.vue'
 import { useEditorStore, type DocumentMeta } from './stores/editor'
 import { useAuthStore } from './stores/auth'
 import { fetchDocument, portableTextToHtml, type ContentDocument } from './services/sanity'
-import { apiPublishDocument, apiSaveDocument } from './services/api'
+import { apiGetDocument, apiPublishDocument, apiSaveDocument } from './services/api'
 import { trackException, trackEvent } from './services/appInsights'
 import { runtimeConfig } from './config/runtime'
 
@@ -22,16 +22,24 @@ const auth = useAuthStore()
 const draftPrefix = runtimeConfig.content.draftPrefix
 
 async function onDocumentSelected(doc: ContentDocument) {
-  const full = await fetchDocument(doc._id)
-  if (!full) {
-    console.error('[open] could not fetch selected document', doc._id)
-    trackEvent('document_open_failed_not_found', { documentId: doc._id })
-    return
+  try {
+    const full = await apiGetDocument(doc._id)
+    if (!full) {
+      console.error('[open] could not fetch selected document', doc._id)
+      trackEvent('document_open_failed_not_found', { documentId: doc._id })
+      return
+    }
+    const bodyHtml = portableTextToHtml(full.body)
+    const titleHtml = `<h1 data-type="title">${escapeHtml(full.title ?? '')}</h1>`
+    editorStore.openDocument(full, titleHtml + bodyHtml)
+    showOpen.value = false
+  } catch (err) {
+    console.error('[open] failed to fetch selected document', doc._id, err)
+    trackException(err instanceof Error ? err : new Error(String(err)), {
+      action: 'open_document',
+      documentId: doc._id,
+    })
   }
-  const bodyHtml = portableTextToHtml(full.body)
-  const titleHtml = `<h1 data-type="title">${escapeHtml(full.title ?? '')}</h1>`
-  editorStore.openDocument(full, titleHtml + bodyHtml)
-  showOpen.value = false
 }
 
 function escapeHtml(str: string): string {

--- a/app/src/services/__tests__/api.test.ts
+++ b/app/src/services/__tests__/api.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { apiSaveDocument, apiPublishDocument, apiCreateDraft, AuthError, clearRedirectTimestamp, AUTH_REDIRECT_TS_KEY } from '../api.js'
+import {
+  apiSaveDocument,
+  apiPublishDocument,
+  apiCreateDraft,
+  apiGetDocument,
+  AuthError,
+  clearRedirectTimestamp,
+  AUTH_REDIRECT_TS_KEY,
+} from '../api.js'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -238,5 +246,37 @@ describe('apiCreateDraft', () => {
   it('throws on a non-2xx response', async () => {
     mockFetch.mockResolvedValue(makeResponse(400, { error: '"slug" is required' }))
     await expect(apiCreateDraft('Post', '')).rejects.toThrow('"slug" is required')
+  })
+})
+
+// ── apiGetDocument ─────────────────────────────────────────────────────────────
+
+describe('apiGetDocument', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('sends a GET request to the document endpoint', async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, { _id: 'drafts.doc-123' }))
+    await apiGetDocument('drafts.doc-123')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/sanity/documents/drafts.doc-123',
+      expect.objectContaining({ redirect: 'manual' }),
+    )
+  })
+
+  it('encodes special characters in the document ID', async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, { _id: 'drafts.some/id' }))
+    await apiGetDocument('drafts.some/id')
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain(encodeURIComponent('drafts.some/id'))
+  })
+
+  it('returns null when API returns null', async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, null))
+    const result = await apiGetDocument('missing-id')
+    expect(result).toBeNull()
   })
 })

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -127,6 +127,11 @@ export async function apiListDocuments(): Promise<ContentDocument[]> {
   return apiFetch<ContentDocument[]>('/api/sanity/documents')
 }
 
+/** Fetches a single content document (draft or published) via the API proxy. */
+export async function apiGetDocument(id: string): Promise<ContentDocument | null> {
+  return apiFetch<ContentDocument | null>(`/api/sanity/documents/${encodeURIComponent(id)}`)
+}
+
 /** Fetches all image assets from Sanity via the API proxy. */
 export async function apiListImages(): Promise<ImageAsset[]> {
   return apiFetch<ImageAsset[]>('/api/sanity/images')


### PR DESCRIPTION
## Why
Opening a document from the Open document modal failed for unpublished drafts because the app fetched selected documents through the public Sanity client, which cannot read draft IDs.

## What changed
- Added an authenticated API endpoint: `GET /api/sanity/documents/{id}` to fetch a single document (draft or published).
- Added `apiGetDocument(id)` in the frontend API service.
- Updated `App.vue` open-document flow to use `apiGetDocument` and report failures through existing telemetry.
- Added tests for the new API function and frontend service behavior.

## Notes for review
This change is intentionally scoped to the open-document path. Publish flow and list behavior are unchanged.