### PR TITLE
feat: schema-driven metadata modal with multi-type Sanity mapping

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -121,6 +121,7 @@ jobs:
           SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           SANITY_TOKEN: ${{ secrets.VITE_SANITY_TOKEN }}
           SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
+          SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -138,6 +139,7 @@ jobs:
         env:
           VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
+          VITE_SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
           SANITY_TOKEN: ${{ secrets.VITE_SANITY_TOKEN }}
 
   build:
@@ -166,4 +168,5 @@ jobs:
         env:
           VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
+          VITE_SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
           VITE_APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -67,6 +67,7 @@ jobs:
               sanityToken="${{ secrets.SANITY_TOKEN }}" \
               sanityProjectId="${{ secrets.SANITY_PROJECT_ID }}" \
               sanityDataset="${{ secrets.SANITY_DATASET }}" \
+              sanityDocumentType="${{ vars.SANITY_DOCUMENT_TYPE || '' }}" \
             --deny-settings-mode none \
             --action-on-unmanage detachAll \
             --yes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
         env:
           VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
+          VITE_SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
         run: npm run build
 
       - name: Deploy to Azure Static Web Apps

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A minimal, focused writing environment built with [Vue 3](https://vuejs.org) and
    VITE_SANITY_BODY_FIELD=body
    VITE_SANITY_SLUG_FIELD=slug
    VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
+   # Optional: JSON multi-type schema config (overrides the single-type vars above)
+   # VITE_SANITY_SCHEMA_CONFIG={"defaultType":"blog","types":[{"name":"blog","label":"Blog","titleField":"title","bodyField":"body","slugField":"slug","publishedAtField":"publishedAt","metadataFields":[{"key":"title","label":"Title","field":"title","type":"string","required":true},{"key":"slug","label":"Slug","field":"slug","type":"slug","required":true},{"key":"publishedAt","label":"Published at","field":"publishedAt","type":"datetime"},{"key":"tags","label":"Tags","field":"tags","type":"stringArray"}]}]}
    VITE_SANITY_DRAFT_PREFIX=drafts.
    VITE_AUTH_PROVIDER=swa
    VITE_AUTH_CURRENT_USER_PATH=/.auth/me
@@ -77,6 +79,7 @@ The app and API expose a typed runtime configuration contract so deployments can
 | `VITE_SANITY_BODY_FIELD` | No | `body` |
 | `VITE_SANITY_SLUG_FIELD` | No | `slug` |
 | `VITE_SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
+| `VITE_SANITY_SCHEMA_CONFIG` | No | unset (falls back to single-type mapping variables) |
 | `VITE_SANITY_DRAFT_PREFIX` | No | `drafts.` |
 | `VITE_AUTH_PROVIDER` | No | `swa` |
 | `VITE_AUTH_CURRENT_USER_PATH` | No | `/.auth/me` for `swa`, `/api/me` for `api` |
@@ -100,6 +103,7 @@ The app and API expose a typed runtime configuration contract so deployments can
 | `SANITY_BODY_FIELD` | No | `body` |
 | `SANITY_SLUG_FIELD` | No | `slug` |
 | `SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
+| `SANITY_SCHEMA_CONFIG` | No | unset (falls back to single-type mapping variables) |
 | `SANITY_DRAFT_PREFIX` | No | `drafts.` |
 | `AUTH_PROVIDER` | No | `swa` |
 | `AUTH_PRINCIPAL_HEADER` | No | `x-ms-client-principal` for `swa`, `x-authenticated-principal` for `header` |
@@ -171,6 +175,7 @@ Optional runtime overrides are supported for reusable deployments. Configure the
 | `SANITY_BODY_FIELD` | `body` |
 | `SANITY_SLUG_FIELD` | `slug` |
 | `SANITY_PUBLISHED_AT_FIELD` | `publishedAt` |
+| `SANITY_SCHEMA_CONFIG` | unset (falls back to single-type mapping variables) |
 | `SANITY_DRAFT_PREFIX` | `drafts.` |
 | `AUTH_PROVIDER` | `swa` |
 | `AUTH_PRINCIPAL_HEADER` | `x-ms-client-principal` for `swa`, `x-authenticated-principal` for `header` |

--- a/app/.env.example
+++ b/app/.env.example
@@ -7,6 +7,8 @@ VITE_SANITY_TITLE_FIELD=title
 VITE_SANITY_BODY_FIELD=body
 VITE_SANITY_SLUG_FIELD=slug
 VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
+# Optional multi-type schema JSON (overrides the single-type mapping above when set)
+# VITE_SANITY_SCHEMA_CONFIG={"defaultType":"blog","types":[{"name":"blog","label":"Blog","titleField":"title","bodyField":"body","slugField":"slug","publishedAtField":"publishedAt","metadataFields":[{"key":"title","label":"Title","field":"title","type":"string","required":true},{"key":"slug","label":"Slug","field":"slug","type":"slug","required":true},{"key":"publishedAt","label":"Published at","field":"publishedAt","type":"datetime"},{"key":"tags","label":"Tags","field":"tags","type":"stringArray"}]}]}
 VITE_SANITY_DRAFT_PREFIX=drafts.
 # Optional auth provider/runtime contract
 VITE_AUTH_PROVIDER=swa

--- a/app/api/src/__tests__/createDraft.test.ts
+++ b/app/api/src/__tests__/createDraft.test.ts
@@ -53,6 +53,8 @@ const VALID_PRINCIPAL = {
 const CREATED_DOC = {
   _id: 'drafts.550e8400-e29b-41d4-a716-446655440000',
   _type: 'blog',
+  _createdAt: '2024-01-01T00:00:00.000Z',
+  _updatedAt: '2024-01-01T00:00:00.000Z',
   title: 'My Post',
   slug: { _type: 'slug', current: 'my-post' },
 }
@@ -152,7 +154,13 @@ describe('createDraft handler', () => {
     const res = await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
 
     expect(res.status).toBe(201)
-    expect(res.jsonBody).toEqual(CREATED_DOC)
+    expect(res.jsonBody).toEqual(
+      expect.objectContaining({
+        _id: CREATED_DOC._id,
+        _type: CREATED_DOC._type,
+        title: CREATED_DOC.title,
+      }),
+    )
   })
 
   it('returns 502 when Sanity client throws', async () => {
@@ -200,7 +208,7 @@ describe('createDraft handler – custom schema mapping', () => {
     const create = vi.fn().mockResolvedValue({ _id: 'drafts.test-id', _type: 'article' })
     vi.mocked(getSanityClient).mockReturnValue({ create } as any)
 
-    await getHandler()(makeRequest({ body: { title: 'My Article', slug: 'my-article' } }))
+    await getHandler()(makeRequest({ body: { title: 'My Article', slug: 'my-article', documentType: 'article' } }))
 
     const doc = vi.mocked(create).mock.calls[0][0] as Record<string, unknown>
     expect(doc['_type']).toBe('article')

--- a/app/api/src/__tests__/listDocuments.test.ts
+++ b/app/api/src/__tests__/listDocuments.test.ts
@@ -100,14 +100,14 @@ describe('listDocuments handler', () => {
     expect(res.jsonBody).toEqual({ error: 'Failed to list documents' })
   })
 
-  it('passes a GROQ query that filters by blog type', async () => {
+  it('passes a GROQ query that filters by configured type list', async () => {
     const mockFetch = vi.fn().mockResolvedValue([])
     vi.mocked(getSanityClient).mockReturnValue({ fetch: mockFetch } as any)
 
     await getHandler()(makeRequest())
 
     const query = mockFetch.mock.calls[0][0] as string
-    expect(query).toContain('_type == "blog"')
+    expect(query).toContain('_type in ["blog"]')
     expect(query).toContain('order(')
   })
 })
@@ -142,8 +142,8 @@ describe('listDocuments handler – custom schema mapping', () => {
     await getHandler()(makeRequest())
 
     const query = mockFetch.mock.calls[0][0] as string
-    expect(query).toContain('_type == "article"')
-    expect(query).not.toContain('_type == "blog"')
+    expect(query).toContain('_type in ["article"]')
+    expect(query).not.toContain('_type in ["blog"]')
   })
 
   it('uses configured field names in the projection', async () => {
@@ -153,8 +153,11 @@ describe('listDocuments handler – custom schema mapping', () => {
     await getHandler()(makeRequest())
 
     const query = mockFetch.mock.calls[0][0] as string
-    expect(query).toContain('"title": headline')
-    expect(query).toContain('"publishedAt": publishedOn')
-    expect(query).toContain('"body": content')
+    expect(query).toContain('"title"')
+    expect(query).toContain('headline')
+    expect(query).toContain('"publishedAt"')
+    expect(query).toContain('publishedOn')
+    expect(query).toContain('"body"')
+    expect(query).toContain('content[_type == "block"][0..10]')
   })
 })

--- a/app/api/src/__tests__/saveDocument.test.ts
+++ b/app/api/src/__tests__/saveDocument.test.ts
@@ -53,7 +53,8 @@ function makePatchClient(opts?: { commitThrows?: boolean }) {
     : vi.fn().mockResolvedValue({ transactionId: 'tx-123' })
   const set = vi.fn().mockReturnValue({ commit })
   const patch = vi.fn().mockReturnValue({ set })
-  return { patch, set, commit }
+  const getDocument = vi.fn().mockResolvedValue({ _id: 'drafts.550e8400-e29b-41d4-a716-446655440000', _type: 'blog' })
+  return { patch, set, commit, getDocument }
 }
 
 const VALID_PRINCIPAL = {
@@ -101,7 +102,7 @@ describe('saveDocument handler', () => {
   it('returns 400 when neither blocks nor title is provided', async () => {
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: {} }))
     expect(res.status).toBe(400)
-    expect(res.jsonBody).toEqual({ error: 'At least one of "blocks" or "title" must be provided' })
+    expect(res.jsonBody).toEqual({ error: 'At least one of "blocks", "title", or "metadata" must be provided' })
   })
 
   it('returns 400 when title is provided but not a string', async () => {
@@ -117,8 +118,8 @@ describe('saveDocument handler', () => {
   })
 
   it('saves blocks without title and returns 204', async () => {
-    const { patch, set, commit } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, commit, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks } }))
@@ -130,8 +131,8 @@ describe('saveDocument handler', () => {
   })
 
   it('saves blocks with title and returns 204', async () => {
-    const { patch, set, commit } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, commit, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks, title: 'My Post' } }))
@@ -142,8 +143,8 @@ describe('saveDocument handler', () => {
   })
 
   it('does not include title field when title is undefined', async () => {
-    const { patch, set } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks: [] } }))
 
@@ -152,8 +153,8 @@ describe('saveDocument handler', () => {
   })
 
   it('saves title without blocks and returns 204', async () => {
-    const { patch, set, commit } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, commit, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { title: 'Updated Title' } }))
 
@@ -164,8 +165,8 @@ describe('saveDocument handler', () => {
   })
 
   it('does not include body field when blocks is undefined', async () => {
-    const { patch, set } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { title: 'Only Title' } }))
 
@@ -175,8 +176,8 @@ describe('saveDocument handler', () => {
   })
 
   it('returns 502 when Sanity client throws', async () => {
-    const { patch } = makePatchClient({ commitThrows: true })
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, getDocument } = makePatchClient({ commitThrows: true })
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks: [] } }))
 
@@ -188,7 +189,10 @@ describe('saveDocument handler', () => {
     const commit = vi.fn().mockRejectedValue('string error')
     const set = vi.fn().mockReturnValue({ commit })
     const patch = vi.fn().mockReturnValue({ set })
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    vi.mocked(getSanityClient).mockReturnValue({
+      patch,
+      getDocument: vi.fn().mockResolvedValue({ _id: 'drafts.550e8400-e29b-41d4-a716-446655440000', _type: 'blog' }),
+    } as any)
 
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks: [] } }))
 
@@ -219,8 +223,8 @@ describe('saveDocument handler – custom schema mapping', () => {
   })
 
   it('uses the configured body field name when saving blocks', async () => {
-    const { patch, set } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     await getHandler()(makeRequest({
@@ -232,8 +236,8 @@ describe('saveDocument handler – custom schema mapping', () => {
   })
 
   it('uses the configured title field name when saving title', async () => {
-    const { patch, set } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     await getHandler()(makeRequest({
       params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
@@ -244,8 +248,8 @@ describe('saveDocument handler – custom schema mapping', () => {
   })
 
   it('uses both configured field names when saving blocks and title together', async () => {
-    const { patch, set } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch } as any)
+    const { patch, set, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     await getHandler()(makeRequest({

--- a/app/api/src/config/runtime.ts
+++ b/app/api/src/config/runtime.ts
@@ -6,6 +6,9 @@ export interface ApiRuntimeConfig {
     apiVersion: string
   }
   content: {
+    defaultType: string
+    typeOrder: string[]
+    types: Record<string, ContentTypeConfig>
     documentType: string
     draftPrefix: string
     titleField: string
@@ -20,6 +23,26 @@ export interface ApiRuntimeConfig {
   }
 }
 
+export type MetadataFieldType = 'string' | 'slug' | 'datetime' | 'stringArray' | 'boolean'
+
+export interface MetadataFieldConfig {
+  key: string
+  label: string
+  field: string
+  type: MetadataFieldType
+  required: boolean
+}
+
+export interface ContentTypeConfig {
+  name: string
+  label: string
+  titleField: string
+  bodyField: string
+  slugField: string
+  publishedAtField: string
+  metadataFields: MetadataFieldConfig[]
+}
+
 let cachedConfig: ApiRuntimeConfig | null = null
 
 function envString(value: string | undefined): string | undefined {
@@ -32,6 +55,214 @@ function readFieldName(value: string | undefined, fallback: string, key: string)
     throw new Error(`Invalid runtime configuration: ${key} must match /^[A-Za-z_][A-Za-z0-9_]*$/`)
   }
   return field
+}
+
+function readMetadataFieldType(
+  value: unknown,
+  fallback: MetadataFieldType,
+  key: string,
+): MetadataFieldType {
+  const type = typeof value === 'string' && value.trim() ? value.trim() : fallback
+  switch (type) {
+    case 'string':
+    case 'slug':
+    case 'datetime':
+    case 'stringArray':
+    case 'boolean':
+      return type
+    default:
+      throw new Error(
+        `Invalid runtime configuration: ${key} must be one of string|slug|datetime|stringArray|boolean`,
+      )
+  }
+}
+
+interface SchemaTypeInput {
+  name: unknown
+  label?: unknown
+  titleField?: unknown
+  bodyField?: unknown
+  slugField?: unknown
+  publishedAtField?: unknown
+  metadataFields?: unknown
+}
+
+interface SchemaConfigInput {
+  defaultType?: unknown
+  types?: unknown
+}
+
+function defaultMetadataFields(type: {
+  titleField: string
+  slugField: string
+  publishedAtField: string
+}): MetadataFieldConfig[] {
+  return [
+    { key: 'title', label: 'Title', field: type.titleField, type: 'string', required: true },
+    { key: 'slug', label: 'Slug', field: type.slugField, type: 'slug', required: true },
+    {
+      key: 'publishedAt',
+      label: 'Published at',
+      field: type.publishedAtField,
+      type: 'datetime',
+      required: false,
+    },
+    { key: 'tags', label: 'Tags', field: 'tags', type: 'stringArray', required: false },
+  ]
+}
+
+function readSchemaType(
+  input: SchemaTypeInput,
+  index: number,
+  fallback: {
+    documentType: string
+    titleField: string
+    bodyField: string
+    slugField: string
+    publishedAtField: string
+  },
+): ContentTypeConfig {
+  const name = readFieldName(
+    typeof input.name === 'string' ? input.name : undefined,
+    fallback.documentType,
+    `SANITY_SCHEMA_CONFIG.types[${index}].name`,
+  )
+  const label = typeof input.label === 'string' && input.label.trim() ? input.label.trim() : name
+  const titleField = readFieldName(
+    typeof input.titleField === 'string' ? input.titleField : undefined,
+    fallback.titleField,
+    `SANITY_SCHEMA_CONFIG.types[${index}].titleField`,
+  )
+  const bodyField = readFieldName(
+    typeof input.bodyField === 'string' ? input.bodyField : undefined,
+    fallback.bodyField,
+    `SANITY_SCHEMA_CONFIG.types[${index}].bodyField`,
+  )
+  const slugField = readFieldName(
+    typeof input.slugField === 'string' ? input.slugField : undefined,
+    fallback.slugField,
+    `SANITY_SCHEMA_CONFIG.types[${index}].slugField`,
+  )
+  const publishedAtField = readFieldName(
+    typeof input.publishedAtField === 'string' ? input.publishedAtField : undefined,
+    fallback.publishedAtField,
+    `SANITY_SCHEMA_CONFIG.types[${index}].publishedAtField`,
+  )
+  const metadataFields = Array.isArray(input.metadataFields)
+    ? input.metadataFields.map((field, fieldIndex) => {
+      const raw = (field ?? {}) as Record<string, unknown>
+      const rawKey = typeof raw['key'] === 'string' ? raw['key'].trim() : ''
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(rawKey)) {
+        throw new Error(
+          `Invalid runtime configuration: SANITY_SCHEMA_CONFIG.types[${index}].metadataFields[${fieldIndex}].key must match /^[A-Za-z_][A-Za-z0-9_]*$/`,
+        )
+      }
+      const key = rawKey
+      const labelText = typeof raw['label'] === 'string' && raw['label'].trim()
+        ? raw['label'].trim()
+        : key
+      const fieldName = readFieldName(
+        typeof raw['field'] === 'string' ? raw['field'] : undefined,
+        key,
+        `SANITY_SCHEMA_CONFIG.types[${index}].metadataFields[${fieldIndex}].field`,
+      )
+      return {
+        key,
+        label: labelText,
+        field: fieldName,
+        type: readMetadataFieldType(
+          raw['type'],
+          'string',
+          `SANITY_SCHEMA_CONFIG.types[${index}].metadataFields[${fieldIndex}].type`,
+        ),
+        required: raw['required'] === true,
+      } satisfies MetadataFieldConfig
+    })
+    : defaultMetadataFields({ titleField, slugField, publishedAtField })
+
+  return {
+    name,
+    label,
+    titleField,
+    bodyField,
+    slugField,
+    publishedAtField,
+    metadataFields,
+  }
+}
+
+function readSchemaConfig(
+  value: string | undefined,
+  fallback: {
+    documentType: string
+    titleField: string
+    bodyField: string
+    slugField: string
+    publishedAtField: string
+  },
+): { defaultType: string; typeOrder: string[]; types: Record<string, ContentTypeConfig> } {
+  const fallbackType: ContentTypeConfig = {
+    name: fallback.documentType,
+    label: fallback.documentType,
+    titleField: fallback.titleField,
+    bodyField: fallback.bodyField,
+    slugField: fallback.slugField,
+    publishedAtField: fallback.publishedAtField,
+    metadataFields: defaultMetadataFields({
+      titleField: fallback.titleField,
+      slugField: fallback.slugField,
+      publishedAtField: fallback.publishedAtField,
+    }),
+  }
+  if (!value) {
+    return {
+      defaultType: fallback.documentType,
+      typeOrder: [fallback.documentType],
+      types: { [fallback.documentType]: fallbackType },
+    }
+  }
+
+  let parsed: SchemaConfigInput
+  try {
+    parsed = JSON.parse(value) as SchemaConfigInput
+  } catch (error) {
+    throw new Error(
+      `Invalid runtime configuration: SANITY_SCHEMA_CONFIG must be valid JSON (${String(error)})`,
+    )
+  }
+
+  if (!Array.isArray(parsed.types) || parsed.types.length === 0) {
+    throw new Error(
+      'Invalid runtime configuration: SANITY_SCHEMA_CONFIG.types must be a non-empty array',
+    )
+  }
+
+  const typeOrder: string[] = []
+  const types: Record<string, ContentTypeConfig> = {}
+  parsed.types.forEach((raw, index) => {
+    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index, fallback)
+    if (types[config.name]) {
+      throw new Error(
+        `Invalid runtime configuration: duplicate type "${config.name}" in SANITY_SCHEMA_CONFIG.types`,
+      )
+    }
+    types[config.name] = config
+    typeOrder.push(config.name)
+  })
+
+  const defaultType = readFieldName(
+    typeof parsed.defaultType === 'string' ? parsed.defaultType : undefined,
+    typeOrder[0] ?? fallback.documentType,
+    'SANITY_SCHEMA_CONFIG.defaultType',
+  )
+
+  if (!types[defaultType]) {
+    throw new Error(
+      `Invalid runtime configuration: defaultType "${defaultType}" is not defined in SANITY_SCHEMA_CONFIG.types`,
+    )
+  }
+
+  return { defaultType, typeOrder, types }
 }
 
 function readAuthProvider(value: string | undefined): ApiRuntimeConfig['auth']['provider'] {
@@ -91,6 +322,24 @@ export function getApiRuntimeConfig(): ApiRuntimeConfig {
     : 'x-authenticated-principal'
   const defaultPrincipalEncoding = authProvider === 'swa' ? 'base64-json' : 'json'
 
+  const fallbackContent = {
+    documentType: readFieldName(process.env['SANITY_DOCUMENT_TYPE'], 'blog', 'SANITY_DOCUMENT_TYPE'),
+    titleField: readFieldName(process.env['SANITY_TITLE_FIELD'], 'title', 'SANITY_TITLE_FIELD'),
+    bodyField: readFieldName(process.env['SANITY_BODY_FIELD'], 'body', 'SANITY_BODY_FIELD'),
+    slugField: readFieldName(process.env['SANITY_SLUG_FIELD'], 'slug', 'SANITY_SLUG_FIELD'),
+    publishedAtField: readFieldName(
+      process.env['SANITY_PUBLISHED_AT_FIELD'],
+      'publishedAt',
+      'SANITY_PUBLISHED_AT_FIELD',
+    ),
+  }
+
+  const schemaConfig = readSchemaConfig(envString(process.env['SANITY_SCHEMA_CONFIG']), fallbackContent)
+  const defaultTypeConfig = schemaConfig.types[schemaConfig.defaultType]
+  if (!defaultTypeConfig) {
+    throw new Error(`Invalid runtime configuration: unknown default type ${schemaConfig.defaultType}`)
+  }
+
   cachedConfig = {
     sanity: {
       projectId: projectId ?? 'unset',
@@ -99,16 +348,15 @@ export function getApiRuntimeConfig(): ApiRuntimeConfig {
       apiVersion: envString(process.env['SANITY_API_VERSION']) ?? '2024-01-01',
     },
     content: {
-      documentType: readFieldName(process.env['SANITY_DOCUMENT_TYPE'], 'blog', 'SANITY_DOCUMENT_TYPE'),
+      defaultType: schemaConfig.defaultType,
+      typeOrder: schemaConfig.typeOrder,
+      types: schemaConfig.types,
+      documentType: defaultTypeConfig.name,
       draftPrefix,
-      titleField: readFieldName(process.env['SANITY_TITLE_FIELD'], 'title', 'SANITY_TITLE_FIELD'),
-      bodyField: readFieldName(process.env['SANITY_BODY_FIELD'], 'body', 'SANITY_BODY_FIELD'),
-      slugField: readFieldName(process.env['SANITY_SLUG_FIELD'], 'slug', 'SANITY_SLUG_FIELD'),
-      publishedAtField: readFieldName(
-        process.env['SANITY_PUBLISHED_AT_FIELD'],
-        'publishedAt',
-        'SANITY_PUBLISHED_AT_FIELD',
-      ),
+      titleField: defaultTypeConfig.titleField,
+      bodyField: defaultTypeConfig.bodyField,
+      slugField: defaultTypeConfig.slugField,
+      publishedAtField: defaultTypeConfig.publishedAtField,
     },
     auth: {
       provider: authProvider,
@@ -126,6 +374,11 @@ export function getApiRuntimeConfig(): ApiRuntimeConfig {
 
 export function clearApiRuntimeConfigCache(): void {
   cachedConfig = null
+}
+
+export function getContentTypeConfig(typeName: string): ContentTypeConfig {
+  const config = getApiRuntimeConfig()
+  return config.content.types[typeName] ?? config.content.types[config.content.defaultType]!
 }
 
 export function isDraftDocumentId(id: string): boolean {

--- a/app/api/src/functions/createDraft.ts
+++ b/app/api/src/functions/createDraft.ts
@@ -4,7 +4,7 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
-import { getApiRuntimeConfig } from '../config/runtime.js'
+import { getApiRuntimeConfig, getContentTypeConfig } from '../config/runtime.js'
 
 app.http('createDraft', {
   methods: ['POST'],
@@ -16,9 +16,9 @@ app.http('createDraft', {
     const auth = requireAuthenticatedPrincipal(request)
     if ('response' in auth) return auth.response
 
-    let body: { title: unknown; slug: unknown }
+    let body: { title: unknown; slug: unknown; documentType?: unknown }
     try {
-      body = (await request.json()) as { title: unknown; slug: unknown }
+      body = (await request.json()) as { title: unknown; slug: unknown; documentType?: unknown }
     } catch {
       return { status: 400, jsonBody: { error: 'Invalid JSON body' } }
     }
@@ -32,16 +32,34 @@ app.http('createDraft', {
 
     try {
       const config = getApiRuntimeConfig()
+      const requestedType = typeof body.documentType === 'string' && body.documentType.trim()
+        ? body.documentType.trim()
+        : config.content.defaultType
+      if (!config.content.types[requestedType]) {
+        return { status: 400, jsonBody: { error: '"documentType" is invalid' } }
+      }
+      const typeConfig = getContentTypeConfig(requestedType)
       const client = getSanityClient()
       const id = `${config.content.draftPrefix}${crypto.randomUUID()}`
       const createPayload: Record<string, unknown> = {
         _id: id,
-        _type: config.content.documentType,
-        [config.content.titleField]: body.title.trim(),
-        [config.content.slugField]: { _type: 'slug', current: body.slug.trim() },
+        _type: typeConfig.name,
+        [typeConfig.titleField]: body.title.trim(),
+        [typeConfig.slugField]: { _type: 'slug', current: body.slug.trim() },
       }
       const doc = await client.create(createPayload as Parameters<typeof client.create>[0])
-      return { status: 201, jsonBody: doc }
+      return {
+        status: 201,
+        jsonBody: {
+          _id: doc._id,
+          _type: typeConfig.name,
+          _createdAt: doc._createdAt,
+          _updatedAt: doc._updatedAt,
+          title: doc[typeConfig.titleField as keyof typeof doc] ?? body.title.trim(),
+          publishedAt: doc[typeConfig.publishedAtField as keyof typeof doc] ?? null,
+          body: doc[typeConfig.bodyField as keyof typeof doc] ?? [],
+        },
+      }
     } catch (err) {
       console.error('[createDraft]', err)
       return { status: 502, jsonBody: { error: 'Failed to create draft' } }

--- a/app/api/src/functions/listDocuments.ts
+++ b/app/api/src/functions/listDocuments.ts
@@ -4,7 +4,20 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
-import { getApiRuntimeConfig } from '../config/runtime.js'
+import { getApiRuntimeConfig, getContentTypeConfig } from '../config/runtime.js'
+
+function quote(value: string): string {
+  return JSON.stringify(value)
+}
+
+function selectByType(
+  typeNames: string[],
+  expressionForType: (typeName: string) => string,
+  fallbackExpression: string,
+): string {
+  const cases = typeNames.map((typeName) => `_type == ${quote(typeName)} => ${expressionForType(typeName)}`)
+  return `select(${cases.join(', ')}, ${fallbackExpression})`
+}
 
 app.http('listDocuments', {
   methods: ['GET'],
@@ -18,14 +31,37 @@ app.http('listDocuments', {
 
     try {
       const config = getApiRuntimeConfig()
+      const typeNames = config.content.typeOrder
+      const typeFilter = typeNames.map((typeName) => quote(typeName)).join(', ')
+      const titleSelect = selectByType(
+        typeNames,
+        (typeName) => getContentTypeConfig(typeName).titleField,
+        "''",
+      )
+      const publishedAtSelect = selectByType(
+        typeNames,
+        (typeName) => getContentTypeConfig(typeName).publishedAtField,
+        'null',
+      )
+      const bodySelect = selectByType(
+        typeNames,
+        (typeName) => `${getContentTypeConfig(typeName).bodyField}[_type == "block"][0..10]`,
+        '[]',
+      )
+      const sortDateSelect = selectByType(
+        typeNames,
+        (typeName) => `coalesce(${getContentTypeConfig(typeName).publishedAtField}, _createdAt)`,
+        '_createdAt',
+      )
       const docs = await getSanityClient().fetch(
-        `*[_type == "${config.content.documentType}"] | order(coalesce(${config.content.publishedAtField}, _createdAt) desc) {
+        `*[_type in [${typeFilter}]] | order(${sortDateSelect} desc) {
           _id,
+          _type,
           _createdAt,
           _updatedAt,
-          "publishedAt": ${config.content.publishedAtField},
-          "title": ${config.content.titleField},
-          "body": ${config.content.bodyField}[_type == "block"][0..10]
+          "publishedAt": ${publishedAtSelect},
+          "title": ${titleSelect},
+          "body": ${bodySelect}
         }`,
       )
       return { status: 200, jsonBody: docs }

--- a/app/api/src/functions/saveDocument.ts
+++ b/app/api/src/functions/saveDocument.ts
@@ -4,7 +4,36 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
-import { getApiRuntimeConfig } from '../config/runtime.js'
+import { getApiRuntimeConfig, getContentTypeConfig, type MetadataFieldConfig } from '../config/runtime.js'
+
+function normalizeMetadataFieldValue(
+  field: MetadataFieldConfig,
+  value: unknown,
+): unknown {
+  switch (field.type) {
+    case 'string':
+    case 'datetime':
+      if (typeof value !== 'string') {
+        throw new Error(`"${field.key}" must be a string`)
+      }
+      return value
+    case 'slug':
+      if (typeof value !== 'string') {
+        throw new Error(`"${field.key}" must be a string`)
+      }
+      return { _type: 'slug', current: value.trim() }
+    case 'stringArray':
+      if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+        throw new Error(`"${field.key}" must be an array of strings`)
+      }
+      return value
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        throw new Error(`"${field.key}" must be a boolean`)
+      }
+      return value
+  }
+}
 
 app.http('saveDocument', {
   methods: ['PATCH'],
@@ -31,9 +60,9 @@ app.http('saveDocument', {
       return { status: 400, jsonBody: { error: 'Invalid document ID' } }
     }
 
-    let body: { blocks?: unknown; title?: unknown }
+    let body: { blocks?: unknown; title?: unknown; metadata?: unknown }
     try {
-      body = (await request.json()) as { blocks?: unknown; title?: unknown }
+      body = (await request.json()) as { blocks?: unknown; title?: unknown; metadata?: unknown }
     } catch {
       return { status: 400, jsonBody: { error: 'Invalid JSON body' } }
     }
@@ -52,23 +81,56 @@ app.http('saveDocument', {
       }
     }
 
-    if (body.blocks === undefined && body.title === undefined) {
+    if (
+      body.metadata !== undefined
+      && (typeof body.metadata !== 'object' || body.metadata === null || Array.isArray(body.metadata))
+    ) {
       return {
         status: 400,
-        jsonBody: { error: 'At least one of "blocks" or "title" must be provided' },
+        jsonBody: { error: '"metadata" must be an object when provided' },
+      }
+    }
+
+    if (body.blocks === undefined && body.title === undefined && body.metadata === undefined) {
+      return {
+        status: 400,
+        jsonBody: { error: 'At least one of "blocks", "title", or "metadata" must be provided' },
       }
     }
 
     try {
       const config = getApiRuntimeConfig()
+      const client = getSanityClient()
+      const existing = await client.getDocument(id)
+      if (!existing || typeof existing._type !== 'string') {
+        return { status: 404, jsonBody: { error: 'Document not found' } }
+      }
+      const typeConfig = getContentTypeConfig(existing._type)
       const fields: Record<string, unknown> = {}
       if (Array.isArray(body.blocks)) {
-        fields[config.content.bodyField] = body.blocks
+        fields[typeConfig.bodyField] = body.blocks
       }
       if (typeof body.title === 'string') {
-        fields[config.content.titleField] = body.title
+        fields[typeConfig.titleField] = body.title
       }
-      await getSanityClient().patch(id).set(fields).commit()
+      if (body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)) {
+        const fieldMap = new Map(typeConfig.metadataFields.map((field) => [field.key, field]))
+        for (const [key, value] of Object.entries(body.metadata as Record<string, unknown>)) {
+          const field = fieldMap.get(key)
+          if (!field) {
+            return { status: 400, jsonBody: { error: `"metadata.${key}" is not configured for this type` } }
+          }
+          try {
+            fields[field.field] = normalizeMetadataFieldValue(field, value)
+          } catch (error) {
+            return {
+              status: 400,
+              jsonBody: { error: error instanceof Error ? error.message : `Invalid value for "${key}"` },
+            }
+          }
+        }
+      }
+      await client.patch(id).set(fields).commit()
       return { status: 204 }
     } catch (err) {
       console.error('[saveDocument]', err)

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { RouterView } from 'vue-router'
 import AppMenuBar from './components/AppMenuBar.vue'
 import OpenDocumentModal from './components/OpenDocumentModal.vue'
+import NewDocumentModal from './components/NewDocumentModal.vue'
 import HelpModal from './components/HelpModal.vue'
 import SettingsModal from './components/SettingsModal.vue'
 import PublishModal from './components/PublishModal.vue'
@@ -14,6 +15,7 @@ import { trackException, trackEvent } from './services/appInsights'
 import { runtimeConfig } from './config/runtime'
 
 const showOpen = ref(false)
+const showNew = ref(false)
 const showHelp = ref(false)
 const showSettings = ref(false)
 const showPublishModal = ref(false)
@@ -66,17 +68,17 @@ const publishTooltip = computed(() => {
   return publishShortcut
 })
 
-async function publishDocument() {
-  if (!canPublish.value) return
-
-  // Check required fields — show modal if any are missing
-  const { title, slug } = editorStore.meta
-  if (!title.trim() || !slug.trim()) {
-    showPublishModal.value = true
+function onNewDocument() {
+  if (!auth.isAuthenticated) {
+    editorStore.resetToPlaceholder()
     return
   }
+  showNew.value = true
+}
 
-  await doPublish()
+async function publishDocument() {
+  if (!canPublish.value) return
+  showPublishModal.value = true
 }
 
 async function onPublishConfirm(meta: DocumentMeta) {
@@ -87,8 +89,8 @@ async function onPublishConfirm(meta: DocumentMeta) {
   editorStore.updateMeta(meta)
 
   try {
-    // Save the updated title to Sanity before publishing
-    await apiSaveDocument(doc._id, undefined, meta.title)
+    // Save metadata updates to Sanity before publishing
+    await apiSaveDocument(doc._id, undefined, meta.title, editorStore.metadataPayload())
   } catch (err) {
     console.error('[publish] pre-publish save failed:', err)
     trackException(err instanceof Error ? err : new Error(String(err)), { action: 'pre_publish_save' })
@@ -150,7 +152,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
     :can-publish="canPublish"
     :is-draft="isDraft"
     :publish-tooltip="publishTooltip"
-    @new="editorStore.resetToPlaceholder()"
+    @new="onNewDocument"
     @open="showOpen = true"
     @publish="publishDocument"
     @help="showHelp = true"
@@ -163,6 +165,11 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
     v-if="showOpen"
     @close="showOpen = false"
     @select="onDocumentSelected"
+  />
+  <NewDocumentModal
+    v-if="showNew"
+    @close="showNew = false"
+    @created="showNew = false"
   />
   <HelpModal
     v-if="showHelp"

--- a/app/src/components/NewDocumentModal.vue
+++ b/app/src/components/NewDocumentModal.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import BaseModal from './BaseModal.vue'
 import { apiCreateDraft } from '../services/api'
 import { useEditorStore } from '../stores/editor'
+import { runtimeConfig } from '../config/runtime'
 
 const emit = defineEmits<{
   close: []
@@ -12,6 +13,7 @@ const emit = defineEmits<{
 const editorStore = useEditorStore()
 
 const title = ref('')
+const selectedType = ref(editorStore.meta.documentType || runtimeConfig.content.defaultType)
 const creating = ref(false)
 const error = ref<string | null>(null)
 
@@ -25,7 +27,7 @@ async function create() {
   creating.value = true
   error.value = null
   try {
-    const doc = await apiCreateDraft(title.value.trim(), slug.value)
+    const doc = await apiCreateDraft(title.value.trim(), slug.value, selectedType.value)
     editorStore.openDocument(doc, '<p></p>')
     emit('created')
     emit('close')
@@ -50,6 +52,23 @@ function onKeydown(e: KeyboardEvent) {
     @close="$emit('close')"
   >
     <div class="new-doc">
+      <label class="field">
+        <span class="field__label">Type</span>
+        <select
+          v-model="selectedType"
+          class="field__input"
+          :disabled="creating"
+        >
+          <option
+            v-for="typeName in runtimeConfig.content.typeOrder"
+            :key="typeName"
+            :value="typeName"
+          >
+            {{ runtimeConfig.content.types[typeName]?.label ?? typeName }}
+          </option>
+        </select>
+      </label>
+
       <label class="field">
         <span class="field__label">Title</span>
         <input

--- a/app/src/components/PublishModal.vue
+++ b/app/src/components/PublishModal.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { reactive, ref, computed, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import BaseModal from './BaseModal.vue'
 import { useEditorStore, type DocumentMeta } from '../stores/editor'
+import { getContentTypeConfig } from '../config/runtime'
 
 const emit = defineEmits<{
   close: []
@@ -9,27 +10,22 @@ const emit = defineEmits<{
 }>()
 
 const store = useEditorStore()
+const typeConfig = computed(() => getContentTypeConfig(store.meta.documentType))
+const fields = computed(() => typeConfig.value.metadataFields)
 
-const activeTab = ref<'required' | 'optional'>('required')
+const values = reactive<Record<string, unknown>>({})
+for (const field of fields.value) {
+  values[field.key] = store.getMetaFieldValue(field.key)
+}
 
-const form = reactive({
-  title: store.meta.title,
-  slug: store.meta.slug,
-  publishedAt: store.meta.publishedAt
-    ? store.meta.publishedAt.slice(0, 16)
-    : '',
-  tags: [...store.meta.tags],
-})
+const slugManuallyEdited = ref(!!String(values['slug'] ?? '').trim())
 
-const slugManuallyEdited = ref(!!store.meta.slug)
-const tagInput = ref('')
-
-// Auto-generate slug from title unless manually edited
 watch(
-  () => form.title,
-  (val) => {
-    if (!slugManuallyEdited.value) {
-      form.slug = store.slugify(val)
+  () => values['title'],
+  (title) => {
+    if (slugManuallyEdited.value || !fields.value.some((field) => field.key === 'slug')) return
+    if (typeof title === 'string') {
+      values['slug'] = store.slugify(title)
     }
   },
 )
@@ -38,144 +34,149 @@ function onSlugInput() {
   slugManuallyEdited.value = true
 }
 
-const canPublish = computed(() => !!form.title.trim() && !!form.slug.trim())
-
-// ── Tags ──────────────────────────────────────────────────────────────────────
-function addTag() {
-  const tag = tagInput.value.trim().replace(/,+$/, '')
-  if (tag && !form.tags.includes(tag)) {
-    form.tags.push(tag)
+function parseStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string')
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
   }
-  tagInput.value = ''
+  return []
 }
 
-function removeTag(tag: string) {
-  form.tags = form.tags.filter((t) => t !== tag)
-}
-
-function onTagKeydown(e: KeyboardEvent) {
-  if (e.key === 'Enter' || e.key === ',') {
-    e.preventDefault()
-    addTag()
-  } else if (e.key === 'Backspace' && tagInput.value === '' && form.tags.length) {
-    form.tags.pop()
+function readFieldValue(key: string, type: string): unknown {
+  const value = values[key]
+  switch (type) {
+    case 'string':
+    case 'slug':
+    case 'datetime':
+      return typeof value === 'string' ? value.trim() : ''
+    case 'stringArray':
+      return parseStringArray(value)
+    case 'boolean':
+      return value === true
+    default:
+      return value
   }
 }
 
-// ── Publish ───────────────────────────────────────────────────────────────────
-function onPublish() {
+const canPublish = computed(() =>
+  fields.value.every((field) => {
+    if (!field.required) return true
+    const value = readFieldValue(field.key, field.type)
+    if (typeof value === 'string') return value.trim().length > 0
+    if (Array.isArray(value)) return value.length > 0
+    if (typeof value === 'boolean') return value
+    return value !== null && value !== undefined
+  }))
+
+function buildMeta(): DocumentMeta {
+  const custom = { ...store.meta.custom }
+  let title = store.meta.title
+  let slug = store.meta.slug
+  let publishedAt = store.meta.publishedAt
+  let tags = [...store.meta.tags]
+
+  for (const field of fields.value) {
+    const value = readFieldValue(field.key, field.type)
+    if (field.key === 'title' && typeof value === 'string') {
+      title = value
+      continue
+    }
+    if (field.key === 'slug' && typeof value === 'string') {
+      slug = value
+      continue
+    }
+    if (field.key === 'publishedAt' && typeof value === 'string') {
+      publishedAt = value ? new Date(value).toISOString() : ''
+      continue
+    }
+    if (field.key === 'tags' && Array.isArray(value)) {
+      tags = value.filter((item): item is string => typeof item === 'string')
+      continue
+    }
+    custom[field.key] = value
+  }
+
+  return {
+    documentType: store.meta.documentType,
+    title,
+    slug,
+    publishedAt,
+    tags,
+    custom,
+  }
+}
+
+function formatDateTimeValue(value: unknown): string {
+  if (typeof value !== 'string' || !value) return ''
+  return value.slice(0, 16)
+}
+
+function saveAndPublish() {
   if (!canPublish.value) return
-  emit('publish', {
-    title: form.title.trim(),
-    slug: form.slug.trim(),
-    publishedAt: form.publishedAt ? new Date(form.publishedAt).toISOString() : '',
-    tags: form.tags,
-  })
+  emit('publish', buildMeta())
 }
 </script>
 
 <template>
   <BaseModal
-    title="Publish document"
+    :title="`Metadata — ${typeConfig.label}`"
     @close="emit('close')"
   >
     <div class="publish-modal">
-      <!-- Tabs -->
       <div
-        class="tabs"
-        role="tablist"
+        v-for="field in fields"
+        :key="field.key"
+        class="field"
       >
-        <button
-          role="tab"
-          :class="['tabs__tab', { 'tabs__tab--active': activeTab === 'required' }]"
-          :aria-selected="activeTab === 'required'"
-          @click="activeTab = 'required'"
+        <label
+          class="field__label"
+          :for="`meta-${field.key}`"
         >
-          Required
-        </button>
-        <button
-          role="tab"
-          :class="['tabs__tab', { 'tabs__tab--active': activeTab === 'optional' }]"
-          :aria-selected="activeTab === 'optional'"
-          @click="activeTab = 'optional'"
+          {{ field.label }}<span v-if="field.required"> *</span>
+        </label>
+        <input
+          v-if="field.type === 'string' || field.type === 'slug'"
+          :id="`meta-${field.key}`"
+          v-model="values[field.key]"
+          class="field__input"
+          :class="{ 'field__input--mono': field.type === 'slug' }"
+          type="text"
+          :placeholder="field.type === 'slug' ? 'auto-generated-from-title' : ''"
+          @input="field.type === 'slug' && onSlugInput()"
         >
-          Optional
-        </button>
-      </div>
-
-      <!-- Required tab -->
-      <div
-        v-show="activeTab === 'required'"
-        role="tabpanel"
-        class="tab-panel"
-      >
-        <label class="field">
-          <span class="field__label">Title</span>
+        <input
+          v-else-if="field.type === 'datetime'"
+          :id="`meta-${field.key}`"
+          :value="formatDateTimeValue(values[field.key])"
+          class="field__input"
+          type="datetime-local"
+          @input="values[field.key] = ($event.target as HTMLInputElement).value"
+        >
+        <input
+          v-else-if="field.type === 'stringArray'"
+          :id="`meta-${field.key}`"
+          :value="Array.isArray(values[field.key]) ? (values[field.key] as string[]).join(', ') : String(values[field.key] ?? '')"
+          class="field__input"
+          type="text"
+          placeholder="comma,separated,values"
+          @input="values[field.key] = ($event.target as HTMLInputElement).value"
+        >
+        <label
+          v-else-if="field.type === 'boolean'"
+          class="field__toggle"
+        >
           <input
-            v-model="form.title"
-            class="field__input"
-            type="text"
-            placeholder="Give your document a title"
-            autofocus
+            :id="`meta-${field.key}`"
+            v-model="values[field.key]"
+            type="checkbox"
           >
-        </label>
-
-        <label class="field">
-          <span class="field__label">Slug</span>
-          <input
-            v-model="form.slug"
-            class="field__input field__input--mono"
-            type="text"
-            placeholder="auto-generated-from-title"
-            @input="onSlugInput"
-          >
+          <span>Enabled</span>
         </label>
       </div>
 
-      <!-- Optional tab -->
-      <div
-        v-show="activeTab === 'optional'"
-        role="tabpanel"
-        class="tab-panel"
-      >
-        <label class="field">
-          <span class="field__label">Published at</span>
-          <input
-            v-model="form.publishedAt"
-            class="field__input"
-            type="datetime-local"
-          >
-        </label>
-
-        <div class="field">
-          <span class="field__label">Tags</span>
-          <div class="tag-input">
-            <span
-              v-for="tag in form.tags"
-              :key="tag"
-              class="tag"
-            >
-              {{ tag }}
-              <button
-                type="button"
-                class="tag__remove"
-                @click="removeTag(tag)"
-              >✕</button>
-            </span>
-            <input
-              v-model="tagInput"
-              class="tag-input__field"
-              type="text"
-              placeholder="Add tag…"
-              @keydown="onTagKeydown"
-              @blur="addTag"
-            >
-          </div>
-          <span class="field__hint">Press Enter or comma to add a tag</span>
-        </div>
-      </div>
-
-      <!-- Actions -->
       <div class="actions">
         <button
           class="btn btn--ghost"
@@ -186,7 +187,7 @@ function onPublish() {
         <button
           class="btn btn--primary"
           :disabled="!canPublish"
-          @click="onPublish"
+          @click="saveAndPublish"
         >
           Publish
         </button>
@@ -199,46 +200,9 @@ function onPublish() {
 .publish-modal {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
-/* ── Tabs ──────────────────────────────────────────────────────────────────── */
-.tabs {
-  display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--ctp-surface0);
-}
-
-.tabs__tab {
-  flex: 1;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--ctp-subtext0);
-  font-size: 0.85rem;
-  font-weight: 500;
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
-  transition: color 0.15s ease, border-color 0.15s ease;
-}
-
-.tabs__tab:hover {
-  color: var(--ctp-text);
-}
-
-.tabs__tab--active {
-  color: var(--ctp-mauve);
-  border-bottom-color: var(--ctp-mauve);
-}
-
-/* ── Tab panels ────────────────────────────────────────────────────────────── */
-.tab-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-/* ── Fields ────────────────────────────────────────────────────────────────── */
 .field {
   display: flex;
   flex-direction: column;
@@ -273,70 +237,17 @@ function onPublish() {
 
 .field__input--mono {
   font-family: ui-monospace, 'Cascadia Code', monospace;
-  font-size: 0.82rem;
   color: var(--ctp-sapphire);
 }
 
-.field__hint {
-  font-size: 0.72rem;
-  color: var(--ctp-overlay1);
-}
-
-/* ── Tag input ─────────────────────────────────────────────────────────────── */
-.tag-input {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  padding: 0.35rem 0.5rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
-  border-radius: 6px;
-  min-height: 2.4rem;
-  align-items: center;
-  transition: border-color 0.15s ease;
-}
-
-.tag-input:focus-within {
-  border-color: var(--ctp-mauve);
-}
-
-.tag {
+.field__toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.15rem 0.45rem;
-  background: var(--ctp-surface1);
-  border-radius: 4px;
-  font-size: 0.8rem;
-  color: var(--ctp-lavender);
-}
-
-.tag__remove {
-  background: none;
-  border: none;
-  color: var(--ctp-overlay1);
-  font-size: 0.65rem;
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-  transition: color 0.1s ease;
-}
-
-.tag__remove:hover {
-  color: var(--ctp-red);
-}
-
-.tag-input__field {
-  flex: 1;
-  min-width: 6rem;
-  background: none;
-  border: none;
-  outline: none;
+  gap: 0.5rem;
   color: var(--ctp-text);
   font-size: 0.9rem;
 }
 
-/* ── Actions ───────────────────────────────────────────────────────────────── */
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -15,6 +15,9 @@ export interface FrontendRuntimeConfig {
     postLoginRedirectParam: string
   }
   content: {
+    defaultType: string
+    typeOrder: string[]
+    types: Record<string, ContentTypeConfig>
     documentType: string
     draftPrefix: string
     titleField: string
@@ -31,6 +34,26 @@ export interface FrontendRuntimeConfig {
   telemetry: {
     applicationInsightsConnectionString?: string
   }
+}
+
+export type MetadataFieldType = 'string' | 'slug' | 'datetime' | 'stringArray' | 'boolean'
+
+export interface MetadataFieldConfig {
+  key: string
+  label: string
+  field: string
+  type: MetadataFieldType
+  required: boolean
+}
+
+export interface ContentTypeConfig {
+  name: string
+  label: string
+  titleField: string
+  bodyField: string
+  slugField: string
+  publishedAtField: string
+  metadataFields: MetadataFieldConfig[]
 }
 
 function envString(value: unknown): string | undefined {
@@ -57,6 +80,241 @@ function readFieldName(value: string | undefined, fallback: string, key: string)
     )
   }
   return field
+}
+
+function readMetadataFieldType(
+  value: unknown,
+  fallback: MetadataFieldType,
+  key: string,
+): MetadataFieldType {
+  const type = typeof value === 'string' && value.trim() ? value.trim() : fallback
+  switch (type) {
+    case 'string':
+    case 'slug':
+    case 'datetime':
+    case 'stringArray':
+    case 'boolean':
+      return type
+    default:
+      throw new Error(
+        `Invalid runtime configuration: ${key} must be one of string|slug|datetime|stringArray|boolean`,
+      )
+  }
+}
+
+interface SchemaTypeInput {
+  name: unknown
+  label?: unknown
+  titleField?: unknown
+  bodyField?: unknown
+  slugField?: unknown
+  publishedAtField?: unknown
+  metadataFields?: unknown
+}
+
+interface SchemaConfigInput {
+  defaultType?: unknown
+  types?: unknown
+}
+
+function defaultMetadataFields(type: {
+  titleField: string
+  slugField: string
+  publishedAtField: string
+}): MetadataFieldConfig[] {
+  return [
+    {
+      key: 'title',
+      label: 'Title',
+      field: type.titleField,
+      type: 'string',
+      required: true,
+    },
+    {
+      key: 'slug',
+      label: 'Slug',
+      field: type.slugField,
+      type: 'slug',
+      required: true,
+    },
+    {
+      key: 'publishedAt',
+      label: 'Published at',
+      field: type.publishedAtField,
+      type: 'datetime',
+      required: false,
+    },
+    {
+      key: 'tags',
+      label: 'Tags',
+      field: 'tags',
+      type: 'stringArray',
+      required: false,
+    },
+  ]
+}
+
+function readSchemaType(
+  input: SchemaTypeInput,
+  index: number,
+  fallback: {
+    documentType: string
+    titleField: string
+    bodyField: string
+    slugField: string
+    publishedAtField: string
+  },
+): ContentTypeConfig {
+  const name = readFieldName(
+    typeof input.name === 'string' ? input.name : undefined,
+    fallback.documentType,
+    `VITE_SANITY_SCHEMA_CONFIG.types[${index}].name`,
+  )
+  const label = typeof input.label === 'string' && input.label.trim() ? input.label.trim() : name
+  const titleField = readFieldName(
+    typeof input.titleField === 'string' ? input.titleField : undefined,
+    fallback.titleField,
+    `VITE_SANITY_SCHEMA_CONFIG.types[${index}].titleField`,
+  )
+  const bodyField = readFieldName(
+    typeof input.bodyField === 'string' ? input.bodyField : undefined,
+    fallback.bodyField,
+    `VITE_SANITY_SCHEMA_CONFIG.types[${index}].bodyField`,
+  )
+  const slugField = readFieldName(
+    typeof input.slugField === 'string' ? input.slugField : undefined,
+    fallback.slugField,
+    `VITE_SANITY_SCHEMA_CONFIG.types[${index}].slugField`,
+  )
+  const publishedAtField = readFieldName(
+    typeof input.publishedAtField === 'string' ? input.publishedAtField : undefined,
+    fallback.publishedAtField,
+    `VITE_SANITY_SCHEMA_CONFIG.types[${index}].publishedAtField`,
+  )
+
+  const metadataFields = Array.isArray(input.metadataFields)
+    ? input.metadataFields.map((field, fieldIndex) => {
+      const raw = (field ?? {}) as Record<string, unknown>
+      const rawKey = typeof raw['key'] === 'string' ? raw['key'].trim() : ''
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(rawKey)) {
+        throw new Error(
+          `Invalid runtime configuration: VITE_SANITY_SCHEMA_CONFIG.types[${index}].metadataFields[${fieldIndex}].key must match /^[A-Za-z_][A-Za-z0-9_]*$/`,
+        )
+      }
+      const key = rawKey
+      const labelText = typeof raw['label'] === 'string' && raw['label'].trim()
+        ? raw['label'].trim()
+        : key
+      const fieldName = readFieldName(
+        typeof raw['field'] === 'string' ? raw['field'] : undefined,
+        key,
+        `VITE_SANITY_SCHEMA_CONFIG.types[${index}].metadataFields[${fieldIndex}].field`,
+      )
+      return {
+        key,
+        label: labelText,
+        field: fieldName,
+        type: readMetadataFieldType(
+          raw['type'],
+          'string',
+          `VITE_SANITY_SCHEMA_CONFIG.types[${index}].metadataFields[${fieldIndex}].type`,
+        ),
+        required: raw['required'] === true,
+      } satisfies MetadataFieldConfig
+    })
+    : defaultMetadataFields({ titleField, slugField, publishedAtField })
+
+  return {
+    name,
+    label,
+    titleField,
+    bodyField,
+    slugField,
+    publishedAtField,
+    metadataFields,
+  }
+}
+
+function readSchemaConfig(
+  value: string | undefined,
+  fallback: {
+    documentType: string
+    titleField: string
+    bodyField: string
+    slugField: string
+    publishedAtField: string
+  },
+): { defaultType: string; typeOrder: string[]; types: Record<string, ContentTypeConfig> } {
+  const fallbackType: ContentTypeConfig = {
+    name: fallback.documentType,
+    label: fallback.documentType,
+    titleField: fallback.titleField,
+    bodyField: fallback.bodyField,
+    slugField: fallback.slugField,
+    publishedAtField: fallback.publishedAtField,
+    metadataFields: defaultMetadataFields({
+      titleField: fallback.titleField,
+      slugField: fallback.slugField,
+      publishedAtField: fallback.publishedAtField,
+    }),
+  }
+
+  if (!value) {
+    return {
+      defaultType: fallback.documentType,
+      typeOrder: [fallback.documentType],
+      types: { [fallback.documentType]: fallbackType },
+    }
+  }
+
+  let parsed: SchemaConfigInput
+  try {
+    parsed = JSON.parse(value) as SchemaConfigInput
+  } catch (error) {
+    throw new Error('Invalid runtime configuration: VITE_SANITY_SCHEMA_CONFIG must be valid JSON', {
+      cause: error,
+    })
+  }
+
+  if (!Array.isArray(parsed.types) || parsed.types.length === 0) {
+    throw new Error(
+      'Invalid runtime configuration: VITE_SANITY_SCHEMA_CONFIG.types must be a non-empty array',
+    )
+  }
+
+  const typeOrder: string[] = []
+  const types: Record<string, ContentTypeConfig> = {}
+
+  parsed.types.forEach((raw, index) => {
+    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index, {
+      documentType: fallback.documentType,
+      titleField: fallback.titleField,
+      bodyField: fallback.bodyField,
+      slugField: fallback.slugField,
+      publishedAtField: fallback.publishedAtField,
+    })
+    if (types[config.name]) {
+      throw new Error(
+        `Invalid runtime configuration: duplicate type "${config.name}" in VITE_SANITY_SCHEMA_CONFIG.types`,
+      )
+    }
+    types[config.name] = config
+    typeOrder.push(config.name)
+  })
+
+  const defaultType = readFieldName(
+    typeof parsed.defaultType === 'string' ? parsed.defaultType : undefined,
+    typeOrder[0] ?? fallback.documentType,
+    'VITE_SANITY_SCHEMA_CONFIG.defaultType',
+  )
+
+  if (!types[defaultType]) {
+    throw new Error(
+      `Invalid runtime configuration: defaultType "${defaultType}" is not defined in VITE_SANITY_SCHEMA_CONFIG.types`,
+    )
+  }
+
+  return { defaultType, typeOrder, types }
 }
 
 function readAuthProvider(value: string | undefined): FrontendRuntimeConfig['auth']['provider'] {
@@ -106,6 +364,28 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
   const authProvider = readAuthProvider(envString(env.VITE_AUTH_PROVIDER))
   const defaultCurrentUserPath = authProvider === 'api' ? '/api/me' : '/.auth/me'
 
+  const fallbackContent = {
+    documentType: readFieldName(
+      envString(env.VITE_SANITY_DOCUMENT_TYPE),
+      'blog',
+      'VITE_SANITY_DOCUMENT_TYPE',
+    ),
+    titleField: readFieldName(envString(env.VITE_SANITY_TITLE_FIELD), 'title', 'VITE_SANITY_TITLE_FIELD'),
+    bodyField: readFieldName(envString(env.VITE_SANITY_BODY_FIELD), 'body', 'VITE_SANITY_BODY_FIELD'),
+    slugField: readFieldName(envString(env.VITE_SANITY_SLUG_FIELD), 'slug', 'VITE_SANITY_SLUG_FIELD'),
+    publishedAtField: readFieldName(
+      envString(env.VITE_SANITY_PUBLISHED_AT_FIELD),
+      'publishedAt',
+      'VITE_SANITY_PUBLISHED_AT_FIELD',
+    ),
+  }
+
+  const schemaConfig = readSchemaConfig(envString(env.VITE_SANITY_SCHEMA_CONFIG), fallbackContent)
+  const defaultTypeConfig = schemaConfig.types[schemaConfig.defaultType]
+  if (!defaultTypeConfig) {
+    throw new Error(`Invalid runtime configuration: unknown default type ${schemaConfig.defaultType}`)
+  }
+
   return {
     app: {
       name: appName,
@@ -127,20 +407,15 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
       postLoginRedirectParam: envString(env.VITE_AUTH_POST_LOGIN_REDIRECT_PARAM) ?? 'post_login_redirect_uri',
     },
     content: {
-      documentType: readFieldName(
-        envString(env.VITE_SANITY_DOCUMENT_TYPE),
-        'blog',
-        'VITE_SANITY_DOCUMENT_TYPE',
-      ),
+      defaultType: schemaConfig.defaultType,
+      typeOrder: schemaConfig.typeOrder,
+      types: schemaConfig.types,
+      documentType: defaultTypeConfig.name,
       draftPrefix,
-      titleField: readFieldName(envString(env.VITE_SANITY_TITLE_FIELD), 'title', 'VITE_SANITY_TITLE_FIELD'),
-      bodyField: readFieldName(envString(env.VITE_SANITY_BODY_FIELD), 'body', 'VITE_SANITY_BODY_FIELD'),
-      slugField: readFieldName(envString(env.VITE_SANITY_SLUG_FIELD), 'slug', 'VITE_SANITY_SLUG_FIELD'),
-      publishedAtField: readFieldName(
-        envString(env.VITE_SANITY_PUBLISHED_AT_FIELD),
-        'publishedAt',
-        'VITE_SANITY_PUBLISHED_AT_FIELD',
-      ),
+      titleField: defaultTypeConfig.titleField,
+      bodyField: defaultTypeConfig.bodyField,
+      slugField: defaultTypeConfig.slugField,
+      publishedAtField: defaultTypeConfig.publishedAtField,
     },
     sanity: {
       projectId,
@@ -155,6 +430,10 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
 }
 
 export const runtimeConfig = createRuntimeConfig(import.meta.env)
+
+export function getContentTypeConfig(typeName: string): ContentTypeConfig {
+  return runtimeConfig.content.types[typeName] ?? runtimeConfig.content.types[runtimeConfig.content.defaultType]!
+}
 
 export function isDraftDocumentId(id: string): boolean {
   return id.startsWith(runtimeConfig.content.draftPrefix)

--- a/app/src/services/__tests__/authProvider.test.ts
+++ b/app/src/services/__tests__/authProvider.test.ts
@@ -25,6 +25,22 @@ function makeConfig(
       ...overrides,
     },
     content: {
+      defaultType: 'blog',
+      typeOrder: ['blog'],
+      types: {
+        blog: {
+          name: 'blog',
+          label: 'Blog',
+          titleField: 'title',
+          bodyField: 'body',
+          slugField: 'slug',
+          publishedAtField: 'publishedAt',
+          metadataFields: [
+            { key: 'title', label: 'Title', field: 'title', type: 'string', required: true },
+            { key: 'slug', label: 'Slug', field: 'slug', type: 'slug', required: true },
+          ],
+        },
+      },
       documentType: 'blog',
       draftPrefix: 'drafts.',
       titleField: 'title',

--- a/app/src/services/__tests__/sanity.schema-mapping.test.ts
+++ b/app/src/services/__tests__/sanity.schema-mapping.test.ts
@@ -13,6 +13,29 @@ import { fetchDocuments, fetchDocument } from '../sanity.js'
 const { mockClientFetch, CUSTOM_CONTENT_CONFIG } = vi.hoisted(() => ({
   mockClientFetch: vi.fn(),
   CUSTOM_CONTENT_CONFIG: {
+    defaultType: 'article',
+    typeOrder: ['article'],
+    types: {
+      article: {
+        name: 'article',
+        label: 'Article',
+        titleField: 'headline',
+        bodyField: 'content',
+        slugField: 'path',
+        publishedAtField: 'publishedOn',
+        metadataFields: [
+          { key: 'title', label: 'Title', field: 'headline', type: 'string', required: true },
+          { key: 'slug', label: 'Slug', field: 'path', type: 'slug', required: true },
+          {
+            key: 'publishedAt',
+            label: 'Published at',
+            field: 'publishedOn',
+            type: 'datetime',
+            required: false,
+          },
+        ],
+      },
+    },
     documentType: 'article',
     titleField: 'headline',
     bodyField: 'content',
@@ -39,6 +62,10 @@ vi.mock('../../config/runtime.js', () => ({
     auth: { loginPath: '/.auth/login/aad', logoutPath: '/.auth/logout', postLoginRedirectParam: 'post_login_redirect_uri' },
     telemetry: {},
   },
+  getContentTypeConfig: vi.fn((typeName: string) => {
+    const name = typeName || CUSTOM_CONTENT_CONFIG.defaultType
+    return CUSTOM_CONTENT_CONFIG.types[name] ?? CUSTOM_CONTENT_CONFIG.types[CUSTOM_CONTENT_CONFIG.defaultType]
+  }),
   isDraftDocumentId: vi.fn((id: string) => id.startsWith('drafts.')),
   toPublishedDocumentId: vi.fn((id: string) => id.replace(/^drafts\./, '')),
   draftDocumentIdPattern: vi.fn(() => /^drafts\..+$/),
@@ -56,8 +83,8 @@ describe('fetchDocuments – custom schema mapping', () => {
     await fetchDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('_type == "article"')
-    expect(query).not.toContain('_type == "blog"')
+    expect(query).toContain('_type in ["article"]')
+    expect(query).not.toContain('_type in ["blog"]')
   })
 
   it('aliases the configured title field to "title" in the projection', async () => {
@@ -65,7 +92,8 @@ describe('fetchDocuments – custom schema mapping', () => {
     await fetchDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('"title": headline')
+    expect(query).toContain('"title"')
+    expect(query).toContain('headline')
   })
 
   it('aliases the configured body field to "body" in the projection', async () => {
@@ -73,7 +101,8 @@ describe('fetchDocuments – custom schema mapping', () => {
     await fetchDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('"body": content')
+    expect(query).toContain('"body"')
+    expect(query).toContain('content[_type == "block"][0..10]')
   })
 
   it('aliases the configured publishedAt field to "publishedAt" in the projection', async () => {
@@ -81,7 +110,8 @@ describe('fetchDocuments – custom schema mapping', () => {
     await fetchDocuments()
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('"publishedAt": publishedOn')
+    expect(query).toContain('"publishedAt"')
+    expect(query).toContain('publishedOn')
   })
 
   it('orders by the configured publishedAt field', async () => {
@@ -106,8 +136,8 @@ describe('fetchDocument – custom schema mapping', () => {
     await fetchDocument('doc-1')
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('_type == "article"')
-    expect(query).not.toContain('_type == "blog"')
+    expect(query).toContain('_type in ["article"]')
+    expect(query).not.toContain('_type in ["blog"]')
   })
 
   it('aliases the configured title field to "title" in the projection', async () => {
@@ -115,7 +145,8 @@ describe('fetchDocument – custom schema mapping', () => {
     await fetchDocument('doc-1')
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('"title": headline')
+    expect(query).toContain('"title"')
+    expect(query).toContain('headline')
   })
 
   it('aliases the configured body field to "body" in the projection', async () => {
@@ -123,7 +154,8 @@ describe('fetchDocument – custom schema mapping', () => {
     await fetchDocument('doc-1')
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('"body": content')
+    expect(query).toContain('"body"')
+    expect(query).toContain('content')
   })
 
   it('aliases the configured publishedAt field to "publishedAt" in the projection', async () => {
@@ -131,6 +163,7 @@ describe('fetchDocument – custom schema mapping', () => {
     await fetchDocument('doc-1')
 
     const query = mockClientFetch.mock.calls[0][0] as string
-    expect(query).toContain('"publishedAt": publishedOn')
+    expect(query).toContain('"publishedAt"')
+    expect(query).toContain('publishedOn')
   })
 })

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -84,12 +84,14 @@ export async function apiSaveDocument(
   id: string,
   blocks?: SanityBodyBlock[],
   title?: string,
+  metadata?: Record<string, unknown>,
 ): Promise<void> {
   await apiFetch<void>(`/api/sanity/documents/${encodeURIComponent(id)}`, {
     method: 'PATCH',
     body: JSON.stringify({
       ...(blocks !== undefined && { blocks }),
       ...(title !== undefined && { title }),
+      ...(metadata !== undefined && { metadata }),
     }),
   })
 }
@@ -98,10 +100,11 @@ export async function apiSaveDocument(
 export async function apiCreateDraft(
   title: string,
   slug: string,
+  documentType?: string,
 ): Promise<ContentDocument> {
   return apiFetch<ContentDocument>('/api/sanity/documents', {
     method: 'POST',
-    body: JSON.stringify({ title, slug }),
+    body: JSON.stringify({ title, slug, ...(documentType ? { documentType } : {}) }),
   })
 }
 

--- a/app/src/services/sanity.ts
+++ b/app/src/services/sanity.ts
@@ -1,7 +1,24 @@
 import { createClient } from '@sanity/client'
-import { runtimeConfig } from '../config/runtime'
+import { runtimeConfig, getContentTypeConfig, type MetadataFieldConfig } from '../config/runtime'
 
 const contentConfig = runtimeConfig.content
+
+function quote(value: string): string {
+  return JSON.stringify(value)
+}
+
+function selectByType(
+  typeNames: string[],
+  expressionForType: (typeName: string) => string,
+  fallbackExpression: string,
+): string {
+  const cases = typeNames.map((typeName) => `_type == ${quote(typeName)} => ${expressionForType(typeName)}`)
+  return `select(${cases.join(', ')}, ${fallbackExpression})`
+}
+
+function metadataExpression(field: MetadataFieldConfig): string {
+  return field.type === 'slug' ? `${field.field}.current` : field.field
+}
 
 // In development the Vite server proxies Sanity API paths through localhost to
 // avoid CORS restrictions. In production and in tests the client talks directly
@@ -61,11 +78,13 @@ export type SanityBodyBlock = SanityBlock | SanityImageBlock | SanityCodeBlock
 
 export interface ContentDocument {
   _id: string
+  _type: string
   _createdAt: string
   _updatedAt: string
   publishedAt?: string
   title: string
   body?: SanityBodyBlock[]
+  metadata?: Record<string, unknown>
 }
 
 /** @deprecated Use {@link ContentDocument} instead. */
@@ -325,14 +344,37 @@ function key() {
 
 /** Fetch list of content documents (title + enough body blocks for 50-word preview). */
 export async function fetchDocuments(): Promise<ContentDocument[]> {
+  const typeNames = contentConfig.typeOrder
+  const typeFilter = typeNames.map((typeName) => quote(typeName)).join(', ')
+  const titleSelect = selectByType(
+    typeNames,
+    (typeName) => getContentTypeConfig(typeName).titleField,
+    "''",
+  )
+  const publishedAtSelect = selectByType(
+    typeNames,
+    (typeName) => getContentTypeConfig(typeName).publishedAtField,
+    'null',
+  )
+  const bodySelect = selectByType(
+    typeNames,
+    (typeName) => `${getContentTypeConfig(typeName).bodyField}[_type == "block"][0..10]`,
+    '[]',
+  )
+  const sortDateSelect = selectByType(
+    typeNames,
+    (typeName) => `coalesce(${getContentTypeConfig(typeName).publishedAtField}, _createdAt)`,
+    '_createdAt',
+  )
   return sanityClient.fetch(`
-    *[_type == "${contentConfig.documentType}"] | order(coalesce(${contentConfig.publishedAtField}, _createdAt) desc) {
+    *[_type in [${typeFilter}]] | order(${sortDateSelect} desc) {
       _id,
+      _type,
       _createdAt,
       _updatedAt,
-      "publishedAt": ${contentConfig.publishedAtField},
-      "title": ${contentConfig.titleField},
-      "body": ${contentConfig.bodyField}[_type == "block"][0..10]
+      "publishedAt": ${publishedAtSelect},
+      "title": ${titleSelect},
+      "body": ${bodySelect}
     }
   `)
 }
@@ -342,14 +384,52 @@ export const fetchBlogDocuments = fetchDocuments
 
 /** Fetch the full body of a single document for editing. */
 export async function fetchDocument(id: string): Promise<ContentDocument | null> {
+  const typeNames = contentConfig.typeOrder
+  const typeFilter = typeNames.map((typeName) => quote(typeName)).join(', ')
+  const titleSelect = selectByType(
+    typeNames,
+    (typeName) => getContentTypeConfig(typeName).titleField,
+    "''",
+  )
+  const publishedAtSelect = selectByType(
+    typeNames,
+    (typeName) => getContentTypeConfig(typeName).publishedAtField,
+    'null',
+  )
+  const bodySelect = selectByType(
+    typeNames,
+    (typeName) => getContentTypeConfig(typeName).bodyField,
+    '[]',
+  )
+  const metadataKeys = Array.from(
+    new Set(typeNames.flatMap((typeName) => getContentTypeConfig(typeName).metadataFields.map((field) => field.key))),
+  )
+  const metadataProjection = metadataKeys.length
+    ? metadataKeys
+      .map((key) => {
+        const valueSelect = selectByType(
+          typeNames,
+          (typeName) => {
+            const field = getContentTypeConfig(typeName).metadataFields.find((item) => item.key === key)
+            return field ? metadataExpression(field) : 'null'
+          },
+          'null',
+        )
+        return `"${key}": ${valueSelect}`
+      })
+      .join(',\n      ')
+    : ''
+
   return sanityClient.fetch(
-    `*[_type == "${contentConfig.documentType}" && _id == $id][0]{
+    `*[_type in [${typeFilter}] && _id == $id][0]{
       _id,
+      _type,
       _createdAt,
       _updatedAt,
-      "publishedAt": ${contentConfig.publishedAtField},
-      "title": ${contentConfig.titleField},
-      "body": ${contentConfig.bodyField}
+      "publishedAt": ${publishedAtSelect},
+      "title": ${titleSelect},
+      "body": ${bodySelect},
+      "metadata": {${metadataProjection}}
     }`,
     { id },
   )

--- a/app/src/stores/editor.ts
+++ b/app/src/stores/editor.ts
@@ -2,13 +2,15 @@ import { defineStore } from 'pinia'
 import { ref, shallowRef } from 'vue'
 import type { ContentDocument } from '../services/sanity'
 import { INTRO_HTML } from '../constants'
-import { runtimeConfig } from '../config/runtime'
+import { runtimeConfig, getContentTypeConfig } from '../config/runtime'
 
 export interface DocumentMeta {
+  documentType: string
   title: string
   slug: string
   publishedAt: string
   tags: string[]
+  custom: Record<string, unknown>
 }
 
 const ns = runtimeConfig.app.storageNamespace
@@ -18,6 +20,63 @@ export const CONTENT_KEY = `${ns}-content`
 interface PersistedSession {
   activeDocument: ContentDocument | null
   meta: DocumentMeta
+}
+
+function defaultMeta(): DocumentMeta {
+  return {
+    documentType: runtimeConfig.content.defaultType,
+    title: '',
+    slug: '',
+    publishedAt: '',
+    tags: [],
+    custom: {},
+  }
+}
+
+function normalizeMeta(meta: DocumentMeta | null | undefined): DocumentMeta {
+  if (!meta) return defaultMeta()
+  return {
+    documentType: meta.documentType || runtimeConfig.content.defaultType,
+    title: meta.title ?? '',
+    slug: meta.slug ?? '',
+    publishedAt: meta.publishedAt ?? '',
+    tags: Array.isArray(meta.tags) ? meta.tags.filter((item): item is string => typeof item === 'string') : [],
+    custom: meta.custom && typeof meta.custom === 'object' && !Array.isArray(meta.custom) ? meta.custom : {},
+  }
+}
+
+function mapDocumentMeta(doc: ContentDocument): DocumentMeta {
+  const typeConfig = getContentTypeConfig(doc._type || runtimeConfig.content.defaultType)
+  const metadata = doc.metadata ?? {}
+  const title = typeof metadata['title'] === 'string'
+    ? metadata['title']
+    : (doc.title ?? '')
+  const slug = typeof metadata['slug'] === 'string'
+    ? metadata['slug']
+    : slugify(title)
+  const publishedAt = typeof metadata['publishedAt'] === 'string'
+    ? metadata['publishedAt']
+    : (doc.publishedAt ?? doc._updatedAt ?? '')
+  const tags = Array.isArray(metadata['tags']) && metadata['tags'].every((item) => typeof item === 'string')
+    ? [...metadata['tags']] as string[]
+    : []
+
+  const custom: Record<string, unknown> = {}
+  for (const field of typeConfig.metadataFields) {
+    if (field.key === 'title' || field.key === 'slug' || field.key === 'publishedAt' || field.key === 'tags') {
+      continue
+    }
+    custom[field.key] = metadata[field.key] ?? ''
+  }
+
+  return {
+    documentType: doc._type || runtimeConfig.content.defaultType,
+    title,
+    slug,
+    publishedAt,
+    tags,
+    custom,
+  }
 }
 
 function loadSession(): PersistedSession | null {
@@ -53,21 +112,14 @@ export const useEditorStore = defineStore('editor', () => {
   const pendingHtml = ref<string | null>(null)
   const saveStatus = ref<SaveStatus>('idle')
   const publishStatus = ref<PublishStatus>('idle')
-  const meta = ref<DocumentMeta>(
-    saved?.meta ?? { title: '', slug: '', publishedAt: '', tags: [] },
-  )
+  const meta = ref<DocumentMeta>(normalizeMeta(saved?.meta))
 
   /** Registered by HomeView to flush pending autosave before publish. */
   const flushSave = shallowRef<(() => Promise<void>) | null>(null)
 
   function openDocument(doc: ContentDocument, html?: string) {
     activeDocument.value = doc
-    meta.value = {
-      title: doc.title ?? '',
-      slug: slugify(doc.title ?? ''),
-      publishedAt: doc._updatedAt ?? '',
-      tags: [],
-    }
+    meta.value = mapDocumentMeta(doc)
     saveSession(activeDocument.value, meta.value)
     if (html !== undefined) pendingHtml.value = html
   }
@@ -76,7 +128,7 @@ export const useEditorStore = defineStore('editor', () => {
     activeDocument.value = null
     currentContent.value = ''
     pendingHtml.value = null
-    meta.value = { title: '', slug: '', publishedAt: '', tags: [] }
+    meta.value = defaultMeta()
     localStorage.removeItem(SESSION_KEY)
     localStorage.removeItem(CONTENT_KEY)
   }
@@ -91,11 +143,56 @@ export const useEditorStore = defineStore('editor', () => {
   }
 
   function updateMeta(patch: Partial<DocumentMeta>) {
-    meta.value = { ...meta.value, ...patch }
+    meta.value = {
+      ...meta.value,
+      ...patch,
+      custom: patch.custom ? { ...meta.value.custom, ...patch.custom } : meta.value.custom,
+    }
     if (patch.title !== undefined && !meta.value.slug) {
       meta.value.slug = slugify(patch.title)
     }
     saveSession(activeDocument.value, meta.value)
+  }
+
+  function updateMetaField(key: string, value: unknown) {
+    if (key === 'title' && typeof value === 'string') {
+      updateMeta({ title: value })
+      return
+    }
+    if (key === 'slug' && typeof value === 'string') {
+      updateMeta({ slug: value })
+      return
+    }
+    if (key === 'publishedAt' && typeof value === 'string') {
+      updateMeta({ publishedAt: value })
+      return
+    }
+    if (key === 'tags' && Array.isArray(value)) {
+      updateMeta({ tags: value.filter((item): item is string => typeof item === 'string') })
+      return
+    }
+    updateMeta({ custom: { [key]: value } })
+  }
+
+  function getMetaFieldValue(key: string): unknown {
+    if (key === 'title') return meta.value.title
+    if (key === 'slug') return meta.value.slug
+    if (key === 'publishedAt') return meta.value.publishedAt
+    if (key === 'tags') return meta.value.tags
+    return meta.value.custom[key]
+  }
+
+  function metadataPayload(): Record<string, unknown> {
+    const typeConfig = getContentTypeConfig(meta.value.documentType)
+    const payload: Record<string, unknown> = {}
+    for (const field of typeConfig.metadataFields) {
+      if (field.key === 'title') payload[field.key] = meta.value.title
+      else if (field.key === 'slug') payload[field.key] = meta.value.slug
+      else if (field.key === 'publishedAt') payload[field.key] = meta.value.publishedAt
+      else if (field.key === 'tags') payload[field.key] = meta.value.tags
+      else payload[field.key] = meta.value.custom[field.key] ?? ''
+    }
+    return payload
   }
 
   function setSaveStatus(status: SaveStatus) {
@@ -131,6 +228,9 @@ export const useEditorStore = defineStore('editor', () => {
     resetToPlaceholder,
     setContent,
     updateMeta,
+    updateMetaField,
+    getMetaFieldValue,
+    metadataPayload,
     setSaveStatus,
     setPublishStatus,
     slugify,

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -144,7 +144,11 @@ async function doAutosave() {
         let titleText = extractTitleText(json)
         if (!titleText || titleText === INTRO_TITLE) titleText = 'Untitled'
         const slug = editorStore.slugify(titleText) || 'untitled'
-        const doc = await apiCreateDraft(titleText, slug)
+        const doc = await apiCreateDraft(
+          titleText,
+          slug,
+          editorStore.meta.documentType || runtimeConfig.content.defaultType,
+        )
         // Guard against stale completion: user may have opened another doc
         if (!editorStore.activeDocument) {
           editorStore.openDocument(doc)

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,6 +36,9 @@ param sanityProjectId string
 @description('Sanity dataset name.')
 param sanityDataset string
 
+@description('Sanity document type used by the app and API.')
+param sanityDocumentType string = ''
+
 // ── Resource group ────────────────────────────────────────────────────────────
 
 resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
@@ -83,6 +86,7 @@ module staticWebApp 'modules/static-web-app.bicep' = {
     sanityToken: sanityToken
     sanityProjectId: sanityProjectId
     sanityDataset: sanityDataset
+    sanityDocumentType: sanityDocumentType
     appInsightsConnectionString: appInsights.outputs.connectionString
   }
 }

--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -30,6 +30,9 @@ param sanityProjectId string
 @description('Sanity dataset name.')
 param sanityDataset string
 
+@description('Sanity document type used by the app and API.')
+param sanityDocumentType string = ''
+
 @description('Application Insights connection string.')
 param appInsightsConnectionString string
 
@@ -52,13 +55,18 @@ resource appSettings 'Microsoft.Web/staticSites/config@2023-12-01' = {
   parent: staticWebApp
   name: 'appsettings'
   properties: {
-    AZURE_CLIENT_ID: entraClientId
-    AZURE_CLIENT_SECRET: entraClientSecret
-    AZURE_TENANT_ID: entraTenantId
-    SANITY_TOKEN: sanityToken
-    SANITY_PROJECT_ID: sanityProjectId
-    SANITY_DATASET: sanityDataset
-    APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
+    ...union(
+      {
+        AZURE_CLIENT_ID: entraClientId
+        AZURE_CLIENT_SECRET: entraClientSecret
+        AZURE_TENANT_ID: entraTenantId
+        SANITY_TOKEN: sanityToken
+        SANITY_PROJECT_ID: sanityProjectId
+        SANITY_DATASET: sanityDataset
+        APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
+      },
+      empty(sanityDocumentType) ? {} : { SANITY_DOCUMENT_TYPE: sanityDocumentType },
+    )
   }
 }
 


### PR DESCRIPTION
This change removes hardcoded metadata assumptions and makes document metadata editing/publish behavior driven by runtime schema configuration. The goal is to support reusable deployments with different Sanity mappings and multiple document types without code edits.

## What changed
- Added a config-first multi-type schema contract in frontend and API runtime config, including backward-compatible fallback to existing single-type variables.
- Reworked content querying and persistence to resolve fields per document `_type` (list, fetch, create draft, save metadata/body).
- Replaced the fixed publish metadata form with a dynamic metadata modal that renders configured fields and required validation rules.
- Updated editor state to carry document type plus dynamic metadata values through create, autosave, save, and publish flows.
- Added document type selection in new draft creation.
- Updated tests and docs for the new schema contract.

## Deployment and infra behavior
- Infrastructure and workflows now support deployment-specific document type overrides via `SANITY_DOCUMENT_TYPE` / `VITE_SANITY_DOCUMENT_TYPE`.
- If no override is set, runtime keeps the existing default behavior (`blog`).
- Azure app settings only include `SANITY_DOCUMENT_TYPE` when explicitly provided, so this is opt-in per deployment.

## Non-obvious notes
- A dedicated schema-discovery API endpoint is still deferred; frontend/backend currently share the same runtime schema contract.
- Existing deployments using legacy single-type vars continue to work unchanged.