### PR TITLE
fix: resolve Bicep parse error in static web app module

### DIFF
--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -65,7 +65,7 @@ resource appSettings 'Microsoft.Web/staticSites/config@2023-12-01' = {
         SANITY_DATASET: sanityDataset
         APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
       },
-      empty(sanityDocumentType) ? {} : { SANITY_DOCUMENT_TYPE: sanityDocumentType },
+      empty(sanityDocumentType) ? {} : { SANITY_DOCUMENT_TYPE: sanityDocumentType }
     )
   }
 }


### PR DESCRIPTION
## Why
The Deploy Infrastructure workflow failed in the `Deploy infrastructure` step because `infra/modules/static-web-app.bicep` could not compile (`BCP009`), which then caused module resolution failure in `infra/main.bicep` (`BCP104`).

## What changed
I removed a trailing comma from the final argument in the `union(...)` expression that builds Static Web App app settings.

This keeps the existing behavior intact (including conditional `SANITY_DOCUMENT_TYPE`) while making the module parseable by Bicep during CI deployment.

## Notes
This is a targeted syntax fix in a single file with no functional changes beyond unblocking template compilation and deployment.