### PR TITLE
refactor: centralize content queries and remove single-type fetch path

### DIFF
--- a/app/api/src/__tests__/getDocument.test.ts
+++ b/app/api/src/__tests__/getDocument.test.ts
@@ -71,11 +71,13 @@ describe('getDocument handler', () => {
   it('returns 200 with the fetched document', async () => {
     const doc = {
       _id: 'drafts.abc',
+      _type: 'blog',
       _createdAt: '2024-01-01',
       _updatedAt: '2024-01-02',
       publishedAt: null,
       title: 'Draft',
       body: [],
+      metadata: { title: 'Draft', slug: 'draft', publishedAt: null, tags: [] },
     }
     const fetch = vi.fn().mockResolvedValue(doc)
     vi.mocked(getSanityClient).mockReturnValue({ fetch } as any)
@@ -112,10 +114,8 @@ describe('getDocument handler – custom schema mapping', () => {
     process.env = {
       ...originalEnv,
       NODE_ENV: 'test',
-      SANITY_DOCUMENT_TYPE: 'article',
-      SANITY_TITLE_FIELD: 'headline',
-      SANITY_BODY_FIELD: 'content',
-      SANITY_PUBLISHED_AT_FIELD: 'publishedOn',
+      SANITY_SCHEMA_CONFIG:
+        '{"defaultType":"article","types":[{"name":"article","titleField":"headline","bodyField":"content","slugField":"slug","publishedAtField":"publishedOn"},{"name":"note","titleField":"name","bodyField":"blocks","slugField":"path","publishedAtField":"updatedAt"}]}',
     }
     clearApiRuntimeConfigCache()
     vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
@@ -132,9 +132,13 @@ describe('getDocument handler – custom schema mapping', () => {
 
     await getHandler()(makeRequest({ id: 'drafts.abc' }))
     const query = fetch.mock.calls[0][0] as string
-    expect(query).toContain('_type == "article"')
-    expect(query).toContain('"title": headline')
-    expect(query).toContain('"publishedAt": publishedOn')
-    expect(query).toContain('"body": content')
+    expect(query).toContain('_type in ["article", "note"]')
+    expect(query).toContain('_type == "article" => headline')
+    expect(query).toContain('_type == "note" => name')
+    expect(query).toContain('_type == "article" => publishedOn')
+    expect(query).toContain('_type == "note" => updatedAt')
+    expect(query).toContain('_type == "article" => content')
+    expect(query).toContain('_type == "note" => blocks')
+    expect(query).toContain('"metadata":')
   })
 })

--- a/app/api/src/contentQuery.ts
+++ b/app/api/src/contentQuery.ts
@@ -1,0 +1,103 @@
+import type { ApiRuntimeConfig, MetadataFieldConfig } from './config/runtime.js'
+
+function quote(value: string): string {
+  return JSON.stringify(value)
+}
+
+function selectByType(
+  typeNames: string[],
+  expressionForType: (typeName: string) => string,
+  fallbackExpression: string,
+): string {
+  const cases = typeNames.map((typeName) => `_type == ${quote(typeName)} => ${expressionForType(typeName)}`)
+  return `select(${cases.join(', ')}, ${fallbackExpression})`
+}
+
+function metadataExpression(field: MetadataFieldConfig): string {
+  return field.type === 'slug' ? `${field.field}.current` : field.field
+}
+
+export function buildListDocumentsQuery(config: ApiRuntimeConfig): string {
+  const typeNames = config.content.typeOrder
+  const typeFilter = typeNames.map((typeName) => quote(typeName)).join(', ')
+  const titleSelect = selectByType(
+    typeNames,
+    (typeName) => config.content.types[typeName]!.titleField,
+    "''",
+  )
+  const publishedAtSelect = selectByType(
+    typeNames,
+    (typeName) => config.content.types[typeName]!.publishedAtField,
+    'null',
+  )
+  const bodySelect = selectByType(
+    typeNames,
+    (typeName) => `${config.content.types[typeName]!.bodyField}[_type == "block"][0..10]`,
+    '[]',
+  )
+  const sortDateSelect = selectByType(
+    typeNames,
+    (typeName) => `coalesce(${config.content.types[typeName]!.publishedAtField}, _createdAt)`,
+    '_createdAt',
+  )
+  return `*[_type in [${typeFilter}]] | order(${sortDateSelect} desc) {
+    _id,
+    _type,
+    _createdAt,
+    _updatedAt,
+    "publishedAt": ${publishedAtSelect},
+    "title": ${titleSelect},
+    "body": ${bodySelect}
+  }`
+}
+
+export function buildGetDocumentQuery(config: ApiRuntimeConfig): string {
+  const typeNames = config.content.typeOrder
+  const typeFilter = typeNames.map((typeName) => quote(typeName)).join(', ')
+  const titleSelect = selectByType(
+    typeNames,
+    (typeName) => config.content.types[typeName]!.titleField,
+    "''",
+  )
+  const publishedAtSelect = selectByType(
+    typeNames,
+    (typeName) => config.content.types[typeName]!.publishedAtField,
+    'null',
+  )
+  const bodySelect = selectByType(
+    typeNames,
+    (typeName) => config.content.types[typeName]!.bodyField,
+    '[]',
+  )
+  const metadataKeys = Array.from(
+    new Set(
+      typeNames.flatMap((typeName) => config.content.types[typeName]!.metadataFields.map((field) => field.key)),
+    ),
+  )
+  const metadataProjection = metadataKeys.length
+    ? metadataKeys
+      .map((key) => {
+        const valueSelect = selectByType(
+          typeNames,
+          (typeName) => {
+            const field = config.content.types[typeName]!.metadataFields.find((item) => item.key === key)
+            return field ? metadataExpression(field) : 'null'
+          },
+          'null',
+        )
+        return `"${key}": ${valueSelect}`
+      })
+      .join(',\n      ')
+    : ''
+
+  return `*[_type in [${typeFilter}] && _id == $id][0]{
+    _id,
+    _type,
+    _createdAt,
+    _updatedAt,
+    "publishedAt": ${publishedAtSelect},
+    "title": ${titleSelect},
+    "body": ${bodySelect},
+    "metadata": {${metadataProjection}}
+  }`
+}

--- a/app/api/src/functions/getDocument.ts
+++ b/app/api/src/functions/getDocument.ts
@@ -5,6 +5,7 @@ import {
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { getApiRuntimeConfig } from '../config/runtime.js'
+import { buildGetDocumentQuery } from '../contentQuery.js'
 
 app.http('getDocument', {
   methods: ['GET'],
@@ -23,17 +24,7 @@ app.http('getDocument', {
 
     try {
       const config = getApiRuntimeConfig()
-      const doc = await getSanityClient().fetch(
-        `*[_type == "${config.content.documentType}" && _id == $id][0]{
-          _id,
-          _createdAt,
-          _updatedAt,
-          "publishedAt": ${config.content.publishedAtField},
-          "title": ${config.content.titleField},
-          "body": ${config.content.bodyField}
-        }`,
-        { id },
-      )
+      const doc = await getSanityClient().fetch(buildGetDocumentQuery(config), { id })
       return { status: 200, jsonBody: doc ?? null }
     } catch (err) {
       console.error('[getDocument]', err)

--- a/app/api/src/functions/listDocuments.ts
+++ b/app/api/src/functions/listDocuments.ts
@@ -4,20 +4,8 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
-import { getApiRuntimeConfig, getContentTypeConfig } from '../config/runtime.js'
-
-function quote(value: string): string {
-  return JSON.stringify(value)
-}
-
-function selectByType(
-  typeNames: string[],
-  expressionForType: (typeName: string) => string,
-  fallbackExpression: string,
-): string {
-  const cases = typeNames.map((typeName) => `_type == ${quote(typeName)} => ${expressionForType(typeName)}`)
-  return `select(${cases.join(', ')}, ${fallbackExpression})`
-}
+import { getApiRuntimeConfig } from '../config/runtime.js'
+import { buildListDocumentsQuery } from '../contentQuery.js'
 
 app.http('listDocuments', {
   methods: ['GET'],
@@ -31,39 +19,7 @@ app.http('listDocuments', {
 
     try {
       const config = getApiRuntimeConfig()
-      const typeNames = config.content.typeOrder
-      const typeFilter = typeNames.map((typeName) => quote(typeName)).join(', ')
-      const titleSelect = selectByType(
-        typeNames,
-        (typeName) => getContentTypeConfig(typeName).titleField,
-        "''",
-      )
-      const publishedAtSelect = selectByType(
-        typeNames,
-        (typeName) => getContentTypeConfig(typeName).publishedAtField,
-        'null',
-      )
-      const bodySelect = selectByType(
-        typeNames,
-        (typeName) => `${getContentTypeConfig(typeName).bodyField}[_type == "block"][0..10]`,
-        '[]',
-      )
-      const sortDateSelect = selectByType(
-        typeNames,
-        (typeName) => `coalesce(${getContentTypeConfig(typeName).publishedAtField}, _createdAt)`,
-        '_createdAt',
-      )
-      const docs = await getSanityClient().fetch(
-        `*[_type in [${typeFilter}]] | order(${sortDateSelect} desc) {
-          _id,
-          _type,
-          _createdAt,
-          _updatedAt,
-          "publishedAt": ${publishedAtSelect},
-          "title": ${titleSelect},
-          "body": ${bodySelect}
-        }`,
-      )
+      const docs = await getSanityClient().fetch(buildListDocumentsQuery(config))
       return { status: 200, jsonBody: docs }
     } catch (err) {
       console.error('[listDocuments]', err)

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -9,7 +9,7 @@ import SettingsModal from './components/SettingsModal.vue'
 import PublishModal from './components/PublishModal.vue'
 import { useEditorStore, type DocumentMeta } from './stores/editor'
 import { useAuthStore } from './stores/auth'
-import { fetchDocument, portableTextToHtml, type ContentDocument } from './services/sanity'
+import { portableTextToHtml, type ContentDocument } from './services/sanity'
 import { apiGetDocument, apiPublishDocument, apiSaveDocument } from './services/api'
 import { trackException, trackEvent } from './services/appInsights'
 import { runtimeConfig } from './config/runtime'
@@ -118,7 +118,7 @@ async function doPublish() {
   editorStore.setPublishStatus('publishing')
   try {
     const { _id: publishedId } = await apiPublishDocument(doc._id)
-    const published = await fetchDocument(publishedId)
+    const published = await apiGetDocument(publishedId)
     if (!published) {
       console.error('[publish] could not fetch published document', publishedId)
       editorStore.setPublishStatus('error')


### PR DESCRIPTION
This completes a remaining portability gap from issue #141: API document reads still had a single-type assumption in one path, which could break reusable multi-type schema deployments even when runtime config was set.

## What changed
- Added a shared API query builder (`app/api/src/contentQuery.ts`) for configurable multi-type GROQ projections.
- Updated `listDocuments` and `getDocument` handlers to use the shared query builder instead of duplicating query-shaping logic.
- Updated `getDocument` behavior to query across configured `typeOrder` and project `_type` plus configured metadata values.
- Updated publish reload in `app/src/App.vue` to read published content through `apiGetDocument` (same runtime/auth boundary as other document reads) instead of direct frontend Sanity access.
- Expanded `app/api/src/__tests__/getDocument.test.ts` to validate multi-type schema config query behavior.

## Notes for reviewers
- Defaults remain compatibility-safe (`blog` schema, SWA auth paths/providers) and no runtime contract values were removed.
- The refactor intentionally keeps query-generation logic in one API module to reduce future drift between list/get handlers.

Fixes: #141