### PR TITLE
feat!: replace legacy schema env vars with schema config

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -121,7 +121,7 @@ jobs:
           SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           SANITY_TOKEN: ${{ secrets.VITE_SANITY_TOKEN }}
           SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
-          SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
+          SANITY_SCHEMA_CONFIG: ${{ vars.SANITY_SCHEMA_CONFIG }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -139,7 +139,7 @@ jobs:
         env:
           VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
-          VITE_SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
+          VITE_SANITY_SCHEMA_CONFIG: ${{ vars.SANITY_SCHEMA_CONFIG }}
           SANITY_TOKEN: ${{ secrets.VITE_SANITY_TOKEN }}
 
   build:
@@ -168,5 +168,5 @@ jobs:
         env:
           VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
-          VITE_SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
+          VITE_SANITY_SCHEMA_CONFIG: ${{ vars.SANITY_SCHEMA_CONFIG }}
           VITE_APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -67,7 +67,7 @@ jobs:
               sanityToken="${{ secrets.SANITY_TOKEN }}" \
               sanityProjectId="${{ secrets.SANITY_PROJECT_ID }}" \
               sanityDataset="${{ secrets.SANITY_DATASET }}" \
-              sanityDocumentType="${{ vars.SANITY_DOCUMENT_TYPE || '' }}" \
+              sanitySchemaConfig='${{ vars.SANITY_SCHEMA_CONFIG || '' }}' \
             --deny-settings-mode none \
             --action-on-unmanage detachAll \
             --yes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
           VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
-          VITE_SANITY_DOCUMENT_TYPE: ${{ vars.SANITY_DOCUMENT_TYPE }}
+          VITE_SANITY_SCHEMA_CONFIG: ${{ vars.SANITY_SCHEMA_CONFIG }}
         run: npm run build
 
       - name: Deploy to Azure Static Web Apps

--- a/README.md
+++ b/README.md
@@ -69,12 +69,7 @@ Both frontend and API use typed runtime configuration so you can customize schem
 | `VITE_SANITY_PROJECT_ID` | Yes | — |
 | `VITE_SANITY_DATASET` | No | `production` |
 | `VITE_SANITY_API_VERSION` | No | `2024-01-01` |
-| `VITE_SANITY_DOCUMENT_TYPE` | No | `blog` |
-| `VITE_SANITY_TITLE_FIELD` | No | `title` |
-| `VITE_SANITY_BODY_FIELD` | No | `body` |
-| `VITE_SANITY_SLUG_FIELD` | No | `slug` |
-| `VITE_SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
-| `VITE_SANITY_SCHEMA_CONFIG` | No | JSON multi-type schema config. If set, it overrides single-type field mapping. |
+| `VITE_SANITY_SCHEMA_CONFIG` | No | JSON schema config. If unset, the frontend uses a built-in single-type default equivalent to `blog` / `title` / `body` / `slug` / `publishedAt`. |
 | `VITE_SANITY_DRAFT_PREFIX` | No | `drafts.` (must end with `.`) |
 | `VITE_AUTH_PROVIDER` | No | `swa` (`swa` or `api`) |
 | `VITE_AUTH_CURRENT_USER_PATH` | No | `/.auth/me` for `swa`, `/api/me` for `api` |
@@ -98,18 +93,64 @@ Both frontend and API use typed runtime configuration so you can customize schem
 | `SANITY_TOKEN` | Yes | — |
 | `SANITY_DATASET` | No | `production` |
 | `SANITY_API_VERSION` | No | `2024-01-01` |
-| `SANITY_DOCUMENT_TYPE` | No | `blog` |
-| `SANITY_TITLE_FIELD` | No | `title` |
-| `SANITY_BODY_FIELD` | No | `body` |
-| `SANITY_SLUG_FIELD` | No | `slug` |
-| `SANITY_PUBLISHED_AT_FIELD` | No | `publishedAt` |
-| `SANITY_SCHEMA_CONFIG` | No | JSON multi-type schema config. If set, it overrides single-type field mapping. |
+| `SANITY_SCHEMA_CONFIG` | No | JSON schema config. If unset, the API uses the same built-in single-type default as the frontend. |
 | `SANITY_DRAFT_PREFIX` | No | `drafts.` (must end with `.`) |
 | `AUTH_PROVIDER` | No | `swa` (`swa` or `header`) |
 | `AUTH_PRINCIPAL_HEADER` | No | `x-ms-client-principal` for `swa`, `x-authenticated-principal` for `header` |
 | `AUTH_PRINCIPAL_ENCODING` | No | `base64-json` for `swa`, `json` for `header` |
 
 Validation is fail-fast: invalid or missing required settings throw explicit runtime errors.
+
+#### Schema config example
+
+`VITE_SANITY_SCHEMA_CONFIG` and `SANITY_SCHEMA_CONFIG` use the same JSON shape:
+
+```json
+{
+  "defaultType": "blog",
+  "types": [
+    {
+      "name": "blog",
+      "label": "Blog",
+      "titleField": "title",
+      "bodyField": "body",
+      "slugField": "slug",
+      "publishedAtField": "publishedAt",
+      "metadataFields": [
+        { "key": "title", "label": "Title", "field": "title", "type": "string", "required": true },
+        { "key": "slug", "label": "Slug", "field": "slug", "type": "slug", "required": true },
+        { "key": "publishedAt", "label": "Published at", "field": "publishedAt", "type": "datetime" },
+        { "key": "tags", "label": "Tags", "field": "tags", "type": "stringArray" }
+      ]
+    },
+    {
+      "name": "note",
+      "label": "Note",
+      "titleField": "name",
+      "bodyField": "content",
+      "slugField": "path",
+      "publishedAtField": "updatedAt"
+    }
+  ]
+}
+```
+
+When schema config is set, each type must declare `name`, `titleField`, `bodyField`, `slugField`, and `publishedAtField`. The old single-type mapping variables are no longer used as fallbacks. If schema config is unset, the app falls back to this built-in default:
+
+```json
+{
+  "defaultType": "blog",
+  "types": [
+    {
+      "name": "blog",
+      "titleField": "title",
+      "bodyField": "body",
+      "slugField": "slug",
+      "publishedAtField": "publishedAt"
+    }
+  ]
+}
+```
 
 ### Portability boundary
 
@@ -142,7 +183,7 @@ Create these under **Settings → Environments** in the GitHub repository. It is
 
 ### Secrets and variables
 
-Configure the following secrets on **each environment** (not at repository level):
+Configure the following secrets and variables on **each environment** (not at repository level):
 
 #### `dev` environment
 
@@ -151,6 +192,10 @@ Configure the following secrets on **each environment** (not at repository level
 | `VITE_SANITY_PROJECT_ID` | Sanity project ID |
 | `VITE_SANITY_DATASET` | Sanity dataset name (e.g. `dev`) |
 | `VITE_SANITY_TOKEN` | Sanity API token with read/write access |
+
+| Variable | Description |
+|--------|-------------|
+| `SANITY_SCHEMA_CONFIG` | Optional schema config JSON. The workflows pass this to both `VITE_SANITY_SCHEMA_CONFIG` and `SANITY_SCHEMA_CONFIG`. Leave it unset to use the built-in default schema. |
 
 #### `production` environment
 
@@ -166,20 +211,21 @@ Configure the following secrets on **each environment** (not at repository level
 | `SANITY_PROJECT_ID` | Sanity project ID (server-side, for API functions) |
 | `SANITY_DATASET` | Sanity dataset name (server-side, for API functions) |
 
-Optional runtime overrides are supported for reusable deployments. Configure these as **Azure Static Web App application settings** if you need non-default schema/auth mapping:
+| Variable | Description |
+|--------|-------------|
+| `SANITY_SCHEMA_CONFIG` | Optional schema config JSON used by build, integration tests, deployment, and SWA runtime settings. Leave it unset to use the built-in default schema. |
+
+Optional runtime overrides are supported for reusable deployments. Configure these as **Azure Static Web App application settings** if you need custom schema/auth mapping:
 
 | Optional SWA App Setting | Default |
 |---|---|
-| `SANITY_DOCUMENT_TYPE` | `blog` |
-| `SANITY_TITLE_FIELD` | `title` |
-| `SANITY_BODY_FIELD` | `body` |
-| `SANITY_SLUG_FIELD` | `slug` |
-| `SANITY_PUBLISHED_AT_FIELD` | `publishedAt` |
-| `SANITY_SCHEMA_CONFIG` | unset (falls back to single-type mapping variables) |
+| `SANITY_SCHEMA_CONFIG` | unset (uses built-in default schema config) |
 | `SANITY_DRAFT_PREFIX` | `drafts.` |
 | `AUTH_PROVIDER` | `swa` |
 | `AUTH_PRINCIPAL_HEADER` | `x-ms-client-principal` for `swa`, `x-authenticated-principal` for `header` |
 | `AUTH_PRINCIPAL_ENCODING` | `base64-json` for `swa`, `json` for `header` |
+
+The GitHub Actions workflows read the GitHub variable `SANITY_SCHEMA_CONFIG` and expose it as both `VITE_SANITY_SCHEMA_CONFIG` (frontend build/test) and `SANITY_SCHEMA_CONFIG` (API test/runtime).
 
 > [!TIP]
 > `VITE_SANITY_PROJECT_ID` is typically the same across environments. `VITE_SANITY_DATASET` and `VITE_SANITY_TOKEN` should differ — use a read/write token scoped to the appropriate dataset in each environment.

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,13 +1,8 @@
 # Sanity.io project configuration (read-only, public)
 VITE_SANITY_PROJECT_ID=your_project_id
 VITE_SANITY_DATASET=dev
-# Optional Sanity schema mapping
-VITE_SANITY_DOCUMENT_TYPE=blog
-VITE_SANITY_TITLE_FIELD=title
-VITE_SANITY_BODY_FIELD=body
-VITE_SANITY_SLUG_FIELD=slug
-VITE_SANITY_PUBLISHED_AT_FIELD=publishedAt
-# Optional multi-type schema JSON (overrides the single-type mapping above when set)
+# Optional Sanity schema config JSON. If unset, the built-in default schema is:
+# {"defaultType":"blog","types":[{"name":"blog","titleField":"title","bodyField":"body","slugField":"slug","publishedAtField":"publishedAt"}]}
 # VITE_SANITY_SCHEMA_CONFIG={"defaultType":"blog","types":[{"name":"blog","label":"Blog","titleField":"title","bodyField":"body","slugField":"slug","publishedAtField":"publishedAt","metadataFields":[{"key":"title","label":"Title","field":"title","type":"string","required":true},{"key":"slug","label":"Slug","field":"slug","type":"slug","required":true},{"key":"publishedAt","label":"Published at","field":"publishedAt","type":"datetime"},{"key":"tags","label":"Tags","field":"tags","type":"stringArray"}]}]}
 VITE_SANITY_DRAFT_PREFIX=drafts.
 # Optional auth provider/runtime contract

--- a/app/api/src/__tests__/createDraft.test.ts
+++ b/app/api/src/__tests__/createDraft.test.ts
@@ -191,9 +191,18 @@ describe('createDraft handler – custom schema mapping', () => {
     process.env = {
       ...originalEnv,
       NODE_ENV: 'test',
-      SANITY_DOCUMENT_TYPE: 'article',
-      SANITY_TITLE_FIELD: 'headline',
-      SANITY_SLUG_FIELD: 'path',
+      SANITY_SCHEMA_CONFIG: JSON.stringify({
+        defaultType: 'article',
+        types: [
+          {
+            name: 'article',
+            titleField: 'headline',
+            bodyField: 'content',
+            slugField: 'path',
+            publishedAtField: 'publishedOn',
+          },
+        ],
+      }),
     }
     clearApiRuntimeConfigCache()
     vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })

--- a/app/api/src/__tests__/listDocuments.test.ts
+++ b/app/api/src/__tests__/listDocuments.test.ts
@@ -121,10 +121,18 @@ describe('listDocuments handler – custom schema mapping', () => {
     process.env = {
       ...originalEnv,
       NODE_ENV: 'test',
-      SANITY_DOCUMENT_TYPE: 'article',
-      SANITY_TITLE_FIELD: 'headline',
-      SANITY_BODY_FIELD: 'content',
-      SANITY_PUBLISHED_AT_FIELD: 'publishedOn',
+      SANITY_SCHEMA_CONFIG: JSON.stringify({
+        defaultType: 'article',
+        types: [
+          {
+            name: 'article',
+            titleField: 'headline',
+            bodyField: 'content',
+            slugField: 'path',
+            publishedAtField: 'publishedOn',
+          },
+        ],
+      }),
     }
     clearApiRuntimeConfigCache()
     vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })

--- a/app/api/src/__tests__/saveDocument.test.ts
+++ b/app/api/src/__tests__/saveDocument.test.ts
@@ -210,8 +210,18 @@ describe('saveDocument handler – custom schema mapping', () => {
     process.env = {
       ...originalEnv,
       NODE_ENV: 'test',
-      SANITY_TITLE_FIELD: 'headline',
-      SANITY_BODY_FIELD: 'content',
+      SANITY_SCHEMA_CONFIG: JSON.stringify({
+        defaultType: 'article',
+        types: [
+          {
+            name: 'article',
+            titleField: 'headline',
+            bodyField: 'content',
+            slugField: 'path',
+            publishedAtField: 'publishedOn',
+          },
+        ],
+      }),
     }
     clearApiRuntimeConfigCache()
     vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })

--- a/app/api/src/config/__tests__/runtime.test.ts
+++ b/app/api/src/config/__tests__/runtime.test.ts
@@ -44,12 +44,39 @@ describe('getApiRuntimeConfig', () => {
   it('accepts schema overrides', () => {
     process.env['SANITY_PROJECT_ID'] = 'project'
     process.env['SANITY_TOKEN'] = 'token'
-    process.env['SANITY_DOCUMENT_TYPE'] = 'article'
-    process.env['SANITY_TITLE_FIELD'] = 'headline'
+    process.env['SANITY_SCHEMA_CONFIG'] = JSON.stringify({
+      defaultType: 'article',
+      types: [
+        {
+          name: 'article',
+          titleField: 'headline',
+          bodyField: 'content',
+          slugField: 'path',
+          publishedAtField: 'publishedOn',
+        },
+      ],
+    })
 
     const config = getApiRuntimeConfig()
     expect(config.content.documentType).toBe('article')
     expect(config.content.titleField).toBe('headline')
+  })
+
+  it('throws when a schema type omits a required field mapping', () => {
+    process.env['SANITY_PROJECT_ID'] = 'project'
+    process.env['SANITY_TOKEN'] = 'token'
+    process.env['SANITY_SCHEMA_CONFIG'] = JSON.stringify({
+      types: [
+        {
+          name: 'article',
+          bodyField: 'content',
+          slugField: 'path',
+          publishedAtField: 'publishedOn',
+        },
+      ],
+    })
+
+    expect(() => getApiRuntimeConfig()).toThrow('SANITY_SCHEMA_CONFIG.types[0].titleField is required')
   })
 
   it('switches auth defaults for generic header provider', () => {

--- a/app/api/src/config/runtime.ts
+++ b/app/api/src/config/runtime.ts
@@ -43,6 +43,14 @@ export interface ContentTypeConfig {
   metadataFields: MetadataFieldConfig[]
 }
 
+const DEFAULT_CONTENT_FIELDS = {
+  documentType: 'blog',
+  titleField: 'title',
+  bodyField: 'body',
+  slugField: 'slug',
+  publishedAtField: 'publishedAt',
+} as const
+
 let cachedConfig: ApiRuntimeConfig | null = null
 
 function envString(value: string | undefined): string | undefined {
@@ -55,6 +63,14 @@ function readFieldName(value: string | undefined, fallback: string, key: string)
     throw new Error(`Invalid runtime configuration: ${key} must match /^[A-Za-z_][A-Za-z0-9_]*$/`)
   }
   return field
+}
+
+function readRequiredFieldName(value: string | undefined, key: string): string {
+  const field = envString(value)
+  if (!field) {
+    throw new Error(`Invalid runtime configuration: ${key} is required`)
+  }
+  return readFieldName(field, field, key)
 }
 
 function readMetadataFieldType(
@@ -111,41 +127,45 @@ function defaultMetadataFields(type: {
   ]
 }
 
+function defaultContentTypeConfig(): ContentTypeConfig {
+  return {
+    name: DEFAULT_CONTENT_FIELDS.documentType,
+    label: DEFAULT_CONTENT_FIELDS.documentType,
+    titleField: DEFAULT_CONTENT_FIELDS.titleField,
+    bodyField: DEFAULT_CONTENT_FIELDS.bodyField,
+    slugField: DEFAULT_CONTENT_FIELDS.slugField,
+    publishedAtField: DEFAULT_CONTENT_FIELDS.publishedAtField,
+    metadataFields: defaultMetadataFields({
+      titleField: DEFAULT_CONTENT_FIELDS.titleField,
+      slugField: DEFAULT_CONTENT_FIELDS.slugField,
+      publishedAtField: DEFAULT_CONTENT_FIELDS.publishedAtField,
+    }),
+  }
+}
+
 function readSchemaType(
   input: SchemaTypeInput,
   index: number,
-  fallback: {
-    documentType: string
-    titleField: string
-    bodyField: string
-    slugField: string
-    publishedAtField: string
-  },
 ): ContentTypeConfig {
-  const name = readFieldName(
+  const name = readRequiredFieldName(
     typeof input.name === 'string' ? input.name : undefined,
-    fallback.documentType,
     `SANITY_SCHEMA_CONFIG.types[${index}].name`,
   )
   const label = typeof input.label === 'string' && input.label.trim() ? input.label.trim() : name
-  const titleField = readFieldName(
+  const titleField = readRequiredFieldName(
     typeof input.titleField === 'string' ? input.titleField : undefined,
-    fallback.titleField,
     `SANITY_SCHEMA_CONFIG.types[${index}].titleField`,
   )
-  const bodyField = readFieldName(
+  const bodyField = readRequiredFieldName(
     typeof input.bodyField === 'string' ? input.bodyField : undefined,
-    fallback.bodyField,
     `SANITY_SCHEMA_CONFIG.types[${index}].bodyField`,
   )
-  const slugField = readFieldName(
+  const slugField = readRequiredFieldName(
     typeof input.slugField === 'string' ? input.slugField : undefined,
-    fallback.slugField,
     `SANITY_SCHEMA_CONFIG.types[${index}].slugField`,
   )
-  const publishedAtField = readFieldName(
+  const publishedAtField = readRequiredFieldName(
     typeof input.publishedAtField === 'string' ? input.publishedAtField : undefined,
-    fallback.publishedAtField,
     `SANITY_SCHEMA_CONFIG.types[${index}].publishedAtField`,
   )
   const metadataFields = Array.isArray(input.metadataFields)
@@ -193,32 +213,13 @@ function readSchemaType(
 
 function readSchemaConfig(
   value: string | undefined,
-  fallback: {
-    documentType: string
-    titleField: string
-    bodyField: string
-    slugField: string
-    publishedAtField: string
-  },
 ): { defaultType: string; typeOrder: string[]; types: Record<string, ContentTypeConfig> } {
-  const fallbackType: ContentTypeConfig = {
-    name: fallback.documentType,
-    label: fallback.documentType,
-    titleField: fallback.titleField,
-    bodyField: fallback.bodyField,
-    slugField: fallback.slugField,
-    publishedAtField: fallback.publishedAtField,
-    metadataFields: defaultMetadataFields({
-      titleField: fallback.titleField,
-      slugField: fallback.slugField,
-      publishedAtField: fallback.publishedAtField,
-    }),
-  }
+  const fallbackType = defaultContentTypeConfig()
   if (!value) {
     return {
-      defaultType: fallback.documentType,
-      typeOrder: [fallback.documentType],
-      types: { [fallback.documentType]: fallbackType },
+      defaultType: fallbackType.name,
+      typeOrder: [fallbackType.name],
+      types: { [fallbackType.name]: fallbackType },
     }
   }
 
@@ -240,7 +241,7 @@ function readSchemaConfig(
   const typeOrder: string[] = []
   const types: Record<string, ContentTypeConfig> = {}
   parsed.types.forEach((raw, index) => {
-    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index, fallback)
+    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index)
     if (types[config.name]) {
       throw new Error(
         `Invalid runtime configuration: duplicate type "${config.name}" in SANITY_SCHEMA_CONFIG.types`,
@@ -252,7 +253,7 @@ function readSchemaConfig(
 
   const defaultType = readFieldName(
     typeof parsed.defaultType === 'string' ? parsed.defaultType : undefined,
-    typeOrder[0] ?? fallback.documentType,
+    typeOrder[0] ?? fallbackType.name,
     'SANITY_SCHEMA_CONFIG.defaultType',
   )
 
@@ -321,20 +322,7 @@ export function getApiRuntimeConfig(): ApiRuntimeConfig {
     ? 'x-ms-client-principal'
     : 'x-authenticated-principal'
   const defaultPrincipalEncoding = authProvider === 'swa' ? 'base64-json' : 'json'
-
-  const fallbackContent = {
-    documentType: readFieldName(process.env['SANITY_DOCUMENT_TYPE'], 'blog', 'SANITY_DOCUMENT_TYPE'),
-    titleField: readFieldName(process.env['SANITY_TITLE_FIELD'], 'title', 'SANITY_TITLE_FIELD'),
-    bodyField: readFieldName(process.env['SANITY_BODY_FIELD'], 'body', 'SANITY_BODY_FIELD'),
-    slugField: readFieldName(process.env['SANITY_SLUG_FIELD'], 'slug', 'SANITY_SLUG_FIELD'),
-    publishedAtField: readFieldName(
-      process.env['SANITY_PUBLISHED_AT_FIELD'],
-      'publishedAt',
-      'SANITY_PUBLISHED_AT_FIELD',
-    ),
-  }
-
-  const schemaConfig = readSchemaConfig(envString(process.env['SANITY_SCHEMA_CONFIG']), fallbackContent)
+  const schemaConfig = readSchemaConfig(envString(process.env['SANITY_SCHEMA_CONFIG']))
   const defaultTypeConfig = schemaConfig.types[schemaConfig.defaultType]
   if (!defaultTypeConfig) {
     throw new Error(`Invalid runtime configuration: unknown default type ${schemaConfig.defaultType}`)

--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -9,11 +9,7 @@ interface ImportMetaEnv {
   readonly VITE_SANITY_PROJECT_ID?: string
   readonly VITE_SANITY_DATASET?: string
   readonly VITE_SANITY_API_VERSION?: string
-  readonly VITE_SANITY_DOCUMENT_TYPE?: string
-  readonly VITE_SANITY_TITLE_FIELD?: string
-  readonly VITE_SANITY_BODY_FIELD?: string
-  readonly VITE_SANITY_SLUG_FIELD?: string
-  readonly VITE_SANITY_PUBLISHED_AT_FIELD?: string
+  readonly VITE_SANITY_SCHEMA_CONFIG?: string
   readonly VITE_SANITY_DRAFT_PREFIX?: string
   readonly VITE_AUTH_PROVIDER?: string
   readonly VITE_AUTH_CURRENT_USER_PATH?: string

--- a/app/src/config/__tests__/runtime.test.ts
+++ b/app/src/config/__tests__/runtime.test.ts
@@ -46,11 +46,18 @@ describe('createRuntimeConfig', () => {
   it('uses custom schema mapping when provided', () => {
     const config = createRuntimeConfig(
       makeEnv({
-        VITE_SANITY_DOCUMENT_TYPE: 'article',
-        VITE_SANITY_TITLE_FIELD: 'headline',
-        VITE_SANITY_BODY_FIELD: 'content',
-        VITE_SANITY_SLUG_FIELD: 'path',
-        VITE_SANITY_PUBLISHED_AT_FIELD: 'publishedOn',
+        VITE_SANITY_SCHEMA_CONFIG: JSON.stringify({
+          defaultType: 'article',
+          types: [
+            {
+              name: 'article',
+              titleField: 'headline',
+              bodyField: 'content',
+              slugField: 'path',
+              publishedAtField: 'publishedOn',
+            },
+          ],
+        }),
       }),
     )
 
@@ -61,6 +68,21 @@ describe('createRuntimeConfig', () => {
       slugField: 'path',
       publishedAtField: 'publishedOn',
     })
+  })
+
+  it('throws when a schema type omits a required field mapping', () => {
+    expect(() => createRuntimeConfig(makeEnv({
+      VITE_SANITY_SCHEMA_CONFIG: JSON.stringify({
+        types: [
+          {
+            name: 'article',
+            bodyField: 'content',
+            slugField: 'path',
+            publishedAtField: 'publishedOn',
+          },
+        ],
+      }),
+    }))).toThrow('VITE_SANITY_SCHEMA_CONFIG.types[0].titleField is required')
   })
 
   it('switches the default current-user path for api auth provider', () => {

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -56,6 +56,14 @@ export interface ContentTypeConfig {
   metadataFields: MetadataFieldConfig[]
 }
 
+const DEFAULT_CONTENT_FIELDS = {
+  documentType: 'blog',
+  titleField: 'title',
+  bodyField: 'body',
+  slugField: 'slug',
+  publishedAtField: 'publishedAt',
+} as const
+
 function envString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined
 }
@@ -80,6 +88,13 @@ function readFieldName(value: string | undefined, fallback: string, key: string)
     )
   }
   return field
+}
+
+function readRequiredFieldName(value: string | undefined, key: string): string {
+  if (!value) {
+    throw new Error(`Invalid runtime configuration: ${key} is required`)
+  }
+  return readFieldName(value, value, key)
 }
 
 function readMetadataFieldType(
@@ -154,41 +169,45 @@ function defaultMetadataFields(type: {
   ]
 }
 
+function defaultContentTypeConfig(): ContentTypeConfig {
+  return {
+    name: DEFAULT_CONTENT_FIELDS.documentType,
+    label: DEFAULT_CONTENT_FIELDS.documentType,
+    titleField: DEFAULT_CONTENT_FIELDS.titleField,
+    bodyField: DEFAULT_CONTENT_FIELDS.bodyField,
+    slugField: DEFAULT_CONTENT_FIELDS.slugField,
+    publishedAtField: DEFAULT_CONTENT_FIELDS.publishedAtField,
+    metadataFields: defaultMetadataFields({
+      titleField: DEFAULT_CONTENT_FIELDS.titleField,
+      slugField: DEFAULT_CONTENT_FIELDS.slugField,
+      publishedAtField: DEFAULT_CONTENT_FIELDS.publishedAtField,
+    }),
+  }
+}
+
 function readSchemaType(
   input: SchemaTypeInput,
   index: number,
-  fallback: {
-    documentType: string
-    titleField: string
-    bodyField: string
-    slugField: string
-    publishedAtField: string
-  },
 ): ContentTypeConfig {
-  const name = readFieldName(
+  const name = readRequiredFieldName(
     typeof input.name === 'string' ? input.name : undefined,
-    fallback.documentType,
     `VITE_SANITY_SCHEMA_CONFIG.types[${index}].name`,
   )
   const label = typeof input.label === 'string' && input.label.trim() ? input.label.trim() : name
-  const titleField = readFieldName(
+  const titleField = readRequiredFieldName(
     typeof input.titleField === 'string' ? input.titleField : undefined,
-    fallback.titleField,
     `VITE_SANITY_SCHEMA_CONFIG.types[${index}].titleField`,
   )
-  const bodyField = readFieldName(
+  const bodyField = readRequiredFieldName(
     typeof input.bodyField === 'string' ? input.bodyField : undefined,
-    fallback.bodyField,
     `VITE_SANITY_SCHEMA_CONFIG.types[${index}].bodyField`,
   )
-  const slugField = readFieldName(
+  const slugField = readRequiredFieldName(
     typeof input.slugField === 'string' ? input.slugField : undefined,
-    fallback.slugField,
     `VITE_SANITY_SCHEMA_CONFIG.types[${index}].slugField`,
   )
-  const publishedAtField = readFieldName(
+  const publishedAtField = readRequiredFieldName(
     typeof input.publishedAtField === 'string' ? input.publishedAtField : undefined,
-    fallback.publishedAtField,
     `VITE_SANITY_SCHEMA_CONFIG.types[${index}].publishedAtField`,
   )
 
@@ -237,33 +256,14 @@ function readSchemaType(
 
 function readSchemaConfig(
   value: string | undefined,
-  fallback: {
-    documentType: string
-    titleField: string
-    bodyField: string
-    slugField: string
-    publishedAtField: string
-  },
 ): { defaultType: string; typeOrder: string[]; types: Record<string, ContentTypeConfig> } {
-  const fallbackType: ContentTypeConfig = {
-    name: fallback.documentType,
-    label: fallback.documentType,
-    titleField: fallback.titleField,
-    bodyField: fallback.bodyField,
-    slugField: fallback.slugField,
-    publishedAtField: fallback.publishedAtField,
-    metadataFields: defaultMetadataFields({
-      titleField: fallback.titleField,
-      slugField: fallback.slugField,
-      publishedAtField: fallback.publishedAtField,
-    }),
-  }
+  const fallbackType = defaultContentTypeConfig()
 
   if (!value) {
     return {
-      defaultType: fallback.documentType,
-      typeOrder: [fallback.documentType],
-      types: { [fallback.documentType]: fallbackType },
+      defaultType: fallbackType.name,
+      typeOrder: [fallbackType.name],
+      types: { [fallbackType.name]: fallbackType },
     }
   }
 
@@ -286,13 +286,7 @@ function readSchemaConfig(
   const types: Record<string, ContentTypeConfig> = {}
 
   parsed.types.forEach((raw, index) => {
-    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index, {
-      documentType: fallback.documentType,
-      titleField: fallback.titleField,
-      bodyField: fallback.bodyField,
-      slugField: fallback.slugField,
-      publishedAtField: fallback.publishedAtField,
-    })
+    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index)
     if (types[config.name]) {
       throw new Error(
         `Invalid runtime configuration: duplicate type "${config.name}" in VITE_SANITY_SCHEMA_CONFIG.types`,
@@ -304,7 +298,7 @@ function readSchemaConfig(
 
   const defaultType = readFieldName(
     typeof parsed.defaultType === 'string' ? parsed.defaultType : undefined,
-    typeOrder[0] ?? fallback.documentType,
+    typeOrder[0] ?? fallbackType.name,
     'VITE_SANITY_SCHEMA_CONFIG.defaultType',
   )
 
@@ -363,24 +357,7 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
 
   const authProvider = readAuthProvider(envString(env.VITE_AUTH_PROVIDER))
   const defaultCurrentUserPath = authProvider === 'api' ? '/api/me' : '/.auth/me'
-
-  const fallbackContent = {
-    documentType: readFieldName(
-      envString(env.VITE_SANITY_DOCUMENT_TYPE),
-      'blog',
-      'VITE_SANITY_DOCUMENT_TYPE',
-    ),
-    titleField: readFieldName(envString(env.VITE_SANITY_TITLE_FIELD), 'title', 'VITE_SANITY_TITLE_FIELD'),
-    bodyField: readFieldName(envString(env.VITE_SANITY_BODY_FIELD), 'body', 'VITE_SANITY_BODY_FIELD'),
-    slugField: readFieldName(envString(env.VITE_SANITY_SLUG_FIELD), 'slug', 'VITE_SANITY_SLUG_FIELD'),
-    publishedAtField: readFieldName(
-      envString(env.VITE_SANITY_PUBLISHED_AT_FIELD),
-      'publishedAt',
-      'VITE_SANITY_PUBLISHED_AT_FIELD',
-    ),
-  }
-
-  const schemaConfig = readSchemaConfig(envString(env.VITE_SANITY_SCHEMA_CONFIG), fallbackContent)
+  const schemaConfig = readSchemaConfig(envString(env.VITE_SANITY_SCHEMA_CONFIG))
   const defaultTypeConfig = schemaConfig.types[schemaConfig.defaultType]
   if (!defaultTypeConfig) {
     throw new Error(`Invalid runtime configuration: unknown default type ${schemaConfig.defaultType}`)

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,14 +3,127 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
+interface SchemaTypeInput {
+  name: unknown
+  titleField?: unknown
+  bodyField?: unknown
+  slugField?: unknown
+  publishedAtField?: unknown
+}
+
+interface SchemaConfigInput {
+  defaultType?: unknown
+  types?: unknown
+}
+
+interface ContentTypeConfig {
+  name: string
+  titleField: string
+  bodyField: string
+  slugField: string
+  publishedAtField: string
+}
+
+const BUILTIN_CONTENT_TYPE: ContentTypeConfig = {
+  name: 'blog',
+  titleField: 'title',
+  bodyField: 'body',
+  slugField: 'slug',
+  publishedAtField: 'publishedAt',
+}
+
+function envString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function readFieldName(value: string | undefined, key: string): string {
+  if (!value) {
+    throw new Error(`Invalid runtime configuration: ${key} is required`)
+  }
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error(`Invalid runtime configuration: ${key} must match /^[A-Za-z_][A-Za-z0-9_]*$/`)
+  }
+  return value
+}
+
+function readSchemaType(input: SchemaTypeInput, index: number): ContentTypeConfig {
+  return {
+    name: readFieldName(envString(input.name), `VITE_SANITY_SCHEMA_CONFIG.types[${index}].name`),
+    titleField: readFieldName(
+      envString(input.titleField),
+      `VITE_SANITY_SCHEMA_CONFIG.types[${index}].titleField`,
+    ),
+    bodyField: readFieldName(
+      envString(input.bodyField),
+      `VITE_SANITY_SCHEMA_CONFIG.types[${index}].bodyField`,
+    ),
+    slugField: readFieldName(
+      envString(input.slugField),
+      `VITE_SANITY_SCHEMA_CONFIG.types[${index}].slugField`,
+    ),
+    publishedAtField: readFieldName(
+      envString(input.publishedAtField),
+      `VITE_SANITY_SCHEMA_CONFIG.types[${index}].publishedAtField`,
+    ),
+  }
+}
+
+function readSchemaConfig(value: string | undefined): { defaultType: string; types: Record<string, ContentTypeConfig> } {
+  if (!value) {
+    return {
+      defaultType: BUILTIN_CONTENT_TYPE.name,
+      types: { [BUILTIN_CONTENT_TYPE.name]: BUILTIN_CONTENT_TYPE },
+    }
+  }
+
+  let parsed: SchemaConfigInput
+  try {
+    parsed = JSON.parse(value) as SchemaConfigInput
+  } catch (error) {
+    throw new Error('Invalid runtime configuration: VITE_SANITY_SCHEMA_CONFIG must be valid JSON', {
+      cause: error,
+    })
+  }
+
+  if (!Array.isArray(parsed.types) || parsed.types.length === 0) {
+    throw new Error('Invalid runtime configuration: VITE_SANITY_SCHEMA_CONFIG.types must be a non-empty array')
+  }
+
+  const types: Record<string, ContentTypeConfig> = {}
+  const typeOrder: string[] = []
+  for (const [index, raw] of parsed.types.entries()) {
+    const config = readSchemaType((raw ?? {}) as SchemaTypeInput, index)
+    if (types[config.name]) {
+      throw new Error(
+        `Invalid runtime configuration: duplicate type "${config.name}" in VITE_SANITY_SCHEMA_CONFIG.types`,
+      )
+    }
+    types[config.name] = config
+    typeOrder.push(config.name)
+  }
+
+  const defaultType = envString(parsed.defaultType)
+    ? readFieldName(envString(parsed.defaultType), 'VITE_SANITY_SCHEMA_CONFIG.defaultType')
+    : (typeOrder[0] ?? BUILTIN_CONTENT_TYPE.name)
+  if (!types[defaultType]) {
+    throw new Error(
+      `Invalid runtime configuration: defaultType "${defaultType}" is not defined in VITE_SANITY_SCHEMA_CONFIG.types`,
+    )
+  }
+
+  return { defaultType, types }
+}
+
 const SANITY_PROJECT_ID = process.env['VITE_SANITY_PROJECT_ID']
 const SANITY_TOKEN = process.env['SANITY_TOKEN'] ?? ''
 const SANITY_DATASET = process.env['VITE_SANITY_DATASET'] ?? 'production'
-const SANITY_DOCUMENT_TYPE = process.env['VITE_SANITY_DOCUMENT_TYPE'] ?? 'blog'
-const SANITY_TITLE_FIELD = process.env['VITE_SANITY_TITLE_FIELD'] ?? 'title'
-const SANITY_BODY_FIELD = process.env['VITE_SANITY_BODY_FIELD'] ?? 'body'
-const SANITY_SLUG_FIELD = process.env['VITE_SANITY_SLUG_FIELD'] ?? 'slug'
-const SANITY_PUBLISHED_AT_FIELD = process.env['VITE_SANITY_PUBLISHED_AT_FIELD'] ?? 'publishedAt'
+const SANITY_SCHEMA = readSchemaConfig(envString(process.env['VITE_SANITY_SCHEMA_CONFIG']))
+const SANITY_DEFAULT_TYPE = SANITY_SCHEMA.types[SANITY_SCHEMA.defaultType]
+const SANITY_DOCUMENT_TYPE = SANITY_DEFAULT_TYPE.name
+const SANITY_TITLE_FIELD = SANITY_DEFAULT_TYPE.titleField
+const SANITY_BODY_FIELD = SANITY_DEFAULT_TYPE.bodyField
+const SANITY_SLUG_FIELD = SANITY_DEFAULT_TYPE.slugField
+const SANITY_PUBLISHED_AT_FIELD = SANITY_DEFAULT_TYPE.publishedAtField
 const SANITY_DRAFT_PREFIX = process.env['VITE_SANITY_DRAFT_PREFIX'] ?? 'drafts.'
 const AUTH_LOGIN_PATH = process.env['VITE_AUTH_LOGIN_PATH'] ?? '/.auth/login/aad'
 const AUTH_LOGOUT_PATH = process.env['VITE_AUTH_LOGOUT_PATH'] ?? '/.auth/logout'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,8 +36,8 @@ param sanityProjectId string
 @description('Sanity dataset name.')
 param sanityDataset string
 
-@description('Sanity document type used by the app and API.')
-param sanityDocumentType string = ''
+@description('Sanity schema config JSON used by the app and API.')
+param sanitySchemaConfig string = ''
 
 // ── Resource group ────────────────────────────────────────────────────────────
 
@@ -86,7 +86,7 @@ module staticWebApp 'modules/static-web-app.bicep' = {
     sanityToken: sanityToken
     sanityProjectId: sanityProjectId
     sanityDataset: sanityDataset
-    sanityDocumentType: sanityDocumentType
+    sanitySchemaConfig: sanitySchemaConfig
     appInsightsConnectionString: appInsights.outputs.connectionString
   }
 }

--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -30,8 +30,8 @@ param sanityProjectId string
 @description('Sanity dataset name.')
 param sanityDataset string
 
-@description('Sanity document type used by the app and API.')
-param sanityDocumentType string = ''
+@description('Sanity schema config JSON used by the app and API.')
+param sanitySchemaConfig string = ''
 
 @description('Application Insights connection string.')
 param appInsightsConnectionString string
@@ -65,7 +65,7 @@ resource appSettings 'Microsoft.Web/staticSites/config@2023-12-01' = {
         SANITY_DATASET: sanityDataset
         APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
       },
-      empty(sanityDocumentType) ? {} : { SANITY_DOCUMENT_TYPE: sanityDocumentType }
+      empty(sanitySchemaConfig) ? {} : { SANITY_SCHEMA_CONFIG: sanitySchemaConfig }
     )
   }
 }


### PR DESCRIPTION
## Summary

This removes ambiguity around Sanity schema mapping by making schema config the only runtime override path. The docs now explain `VITE_SANITY_SCHEMA_CONFIG` with a concrete example, and the runtime no longer lets legacy single-type env vars silently influence schema-config installs.

The change updates frontend runtime parsing, API runtime parsing, the local Vite dev server mock, tests, GitHub Actions workflows, and Azure infrastructure to use `VITE_SANITY_SCHEMA_CONFIG` / `SANITY_SCHEMA_CONFIG`. When schema config is present, each type must declare its own field mappings; when it is absent, the app falls back to the built-in default `blog` schema.

## Breaking change

- Removed the legacy single-type schema variables from the runtime contract:
  - `VITE_SANITY_DOCUMENT_TYPE`
  - `VITE_SANITY_TITLE_FIELD`
  - `VITE_SANITY_BODY_FIELD`
  - `VITE_SANITY_SLUG_FIELD`
  - `VITE_SANITY_PUBLISHED_AT_FIELD`
  - `SANITY_DOCUMENT_TYPE`
  - `SANITY_TITLE_FIELD`
  - `SANITY_BODY_FIELD`
  - `SANITY_SLUG_FIELD`
  - `SANITY_PUBLISHED_AT_FIELD`
- GitHub Actions and Azure Static Web App settings now expect `SANITY_SCHEMA_CONFIG` instead.
- Leaving `SANITY_SCHEMA_CONFIG` unset still works and uses the built-in default schema config.

## Validation

- `cd app/api && npm test && npm run build`
- `cd app && npm test && npm run lint && npm run build`
- `pre-commit run`