### PR TITLE
fix: remove menu shortcut tooltips and keyboard bindings

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 import AppMenuBar from './components/AppMenuBar.vue'
 import OpenDocumentModal from './components/OpenDocumentModal.vue'
@@ -64,18 +64,6 @@ const isDraft = computed(() =>
   && editorStore.activeDocument._id.startsWith(draftPrefix),
 )
 
-const isMac = navigator.platform.toUpperCase().includes('MAC')
-const publishShortcut = isMac ? '⌘⇧P' : 'Ctrl+Shift+P'
-
-const publishTooltip = computed(() => {
-  if (!auth.isAuthenticated) return 'Sign in to publish'
-  if (!editorStore.activeDocument) return 'No document open'
-  if (!isDraft.value) return 'No new changes'
-  if (editorStore.publishStatus === 'publishing') return 'Publishing…'
-  if (editorStore.saveStatus === 'saving') return `Saving… (${publishShortcut})`
-  return publishShortcut
-})
-
 function onNewDocument() {
   if (!auth.isAuthenticated) {
     editorStore.resetToPlaceholder()
@@ -134,19 +122,9 @@ async function doPublish() {
   }
 }
 
-function onKeydown(e: KeyboardEvent) {
-  const mod = e.metaKey || e.ctrlKey
-  if (mod && e.key === 'n') { e.preventDefault(); editorStore.resetToPlaceholder() }
-  if (mod && e.key === 'o' && auth.isAuthenticated) { e.preventDefault(); showOpen.value = true }
-  if (mod && e.shiftKey && e.key === 'P') { e.preventDefault(); publishDocument() }
-  if (e.key === 'F1') { e.preventDefault(); showHelp.value = true }
-}
-
 onMounted(async () => {
   await auth.initialize()
-  document.addEventListener('keydown', onKeydown)
 })
-onUnmounted(() => document.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
@@ -159,7 +137,6 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
     :has-document="!!editorStore.activeDocument"
     :can-publish="canPublish"
     :is-draft="isDraft"
-    :publish-tooltip="publishTooltip"
     @new="onNewDocument"
     @open="showOpen = true"
     @publish="publishDocument"

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -6,9 +6,6 @@ import type { SaveStatus, PublishStatus } from '../stores/editor'
 import type { AuthUser } from '../stores/auth'
 import { runtimeConfig } from '../config/runtime'
 
-const isMac = navigator.platform.toUpperCase().includes('MAC')
-const mod = isMac ? '⌘' : 'Ctrl+'
-
 const props = defineProps<{
   documentTitle?: string
   saveStatus?: SaveStatus
@@ -18,7 +15,6 @@ const props = defineProps<{
   hasDocument?: boolean
   canPublish?: boolean
   isDraft?: boolean
-  publishTooltip?: string
 }>()
 
 const statusLabel = computed(() => {
@@ -46,34 +42,6 @@ function mobileEmit(event: 'new' | 'open' | 'publish' | 'help' | 'settings' | 's
   mobileMenuOpen.value = false
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   emit(event as any)
-}
-
-// ── Cursor-following shortcut tooltip ─────────────────────────────────────────
-const tooltip = ref<{ label: string; x: number; y: number } | null>(null)
-
-const shortcuts: Record<string, string> = {
-  new:     `${mod}N`,
-  open:    `${mod}O`,
-  publish: `${mod}⇧P`,
-  help:    'F1',
-}
-
-function onEnter(key: string, e: MouseEvent) {
-  const label = key === 'publish' && props.publishTooltip
-    ? props.publishTooltip
-    : shortcuts[key] ?? key
-  tooltip.value = { label, x: e.clientX, y: e.clientY }
-}
-function onMove(key: string, e: MouseEvent) {
-  if (tooltip.value) {
-    const label = key === 'publish' && props.publishTooltip
-      ? props.publishTooltip
-      : shortcuts[key] ?? key
-    tooltip.value = { label, x: e.clientX, y: e.clientY }
-  }
-}
-function onLeave() {
-  tooltip.value = null
 }
 </script>
 
@@ -159,9 +127,6 @@ function onLeave() {
           role="menuitem"
           class="menubar__item"
           @click="$emit('new')"
-          @mouseenter="onEnter('new', $event)"
-          @mousemove="onMove('new', $event)"
-          @mouseleave="onLeave"
         >
           New
         </button>
@@ -175,9 +140,6 @@ function onLeave() {
           :class="{ 'menubar__item--disabled': !isAuthenticated }"
           :disabled="!isAuthenticated"
           @click="isAuthenticated && $emit('open')"
-          @mouseenter="onEnter('open', $event)"
-          @mousemove="onMove('open', $event)"
-          @mouseleave="onLeave"
         >
           Open
         </button>
@@ -191,9 +153,6 @@ function onLeave() {
           :class="{ 'menubar__item--disabled': !canPublish }"
           :disabled="!canPublish"
           @click="canPublish && $emit('publish')"
-          @mouseenter="onEnter('publish', $event)"
-          @mousemove="onMove('publish', $event)"
-          @mouseleave="onLeave"
         >
           Publish
           <span
@@ -238,9 +197,6 @@ function onLeave() {
           title="Help"
           aria-label="Help"
           @click="$emit('help')"
-          @mouseenter="onEnter('help', $event)"
-          @mousemove="onMove('help', $event)"
-          @mouseleave="onLeave"
         >
           <svg
             viewBox="0 0 20 20"
@@ -273,7 +229,6 @@ function onLeave() {
           class="menubar__item menubar__item--user"
           title="Account"
           @click="openUserModal"
-          @mouseleave="onLeave"
         >
           <span class="menubar__avatar menubar__avatar--initials">{{ user?.userDetails?.charAt(0) ?? '?' }}</span>
         </button>
@@ -282,9 +237,6 @@ function onLeave() {
           role="menuitem"
           class="menubar__item menubar__item--signin"
           @click="$emit('signin')"
-          @mouseenter="onEnter('signin', $event)"
-          @mousemove="onMove('signin', $event)"
-          @mouseleave="onLeave"
         >
           Sign in
         </button>
@@ -437,19 +389,7 @@ function onLeave() {
     />
   </Teleport>
 
-  <!-- Floating shortcut tooltip, follows the cursor -->
   <Teleport to="body">
-    <Transition name="tip">
-      <div
-        v-if="tooltip"
-        class="shortcut-tip"
-        :style="{ left: tooltip.x + 'px', top: (tooltip.y + 18) + 'px' }"
-        aria-hidden="true"
-      >
-        {{ tooltip.label }}
-      </div>
-    </Transition>
-    <!-- User profile modal -->
     <UserModal
       v-if="showUserModal && user"
       :user="user"
@@ -778,27 +718,4 @@ function onLeave() {
 .mobile-panel-leave-active { transition: opacity 0.1s ease, transform 0.1s ease; }
 .mobile-panel-enter-from, .mobile-panel-leave-to { opacity: 0; transform: translateY(-4px); }
 
-/* ── Shortcut tooltip ─────────────────────────────────────────────────────── */
-.shortcut-tip {
-  position: fixed;
-  z-index: 9999;
-  pointer-events: none;
-  transform: translateX(-50%);
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
-  font-size: var(--step--2);
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  padding: 0.2em 0.55em;
-  border-radius: 4px;
-  border: 1px solid var(--ctp-surface1);
-  white-space: nowrap;
-  box-shadow: 0 2px 8px color-mix(in srgb, var(--ctp-crust) 40%, transparent);
-}
-
-.tip-enter-active { transition: opacity 0.1s ease, transform 0.1s ease; }
-.tip-leave-active { transition: opacity 0.08s ease; }
-.tip-enter-from  { opacity: 0; transform: translateX(-50%) translateY(-4px); }
-.tip-leave-to    { opacity: 0; }
-.tip-enter-to    { opacity: 1; transform: translateX(-50%) translateY(0); }
 </style>

--- a/app/src/components/HelpModal.vue
+++ b/app/src/components/HelpModal.vue
@@ -2,20 +2,7 @@
 import BaseModal from './BaseModal.vue'
 import { runtimeConfig } from '../config/runtime'
 
-const isMac = navigator.platform.toUpperCase().includes('MAC')
-const mod = isMac ? '⌘' : 'Ctrl+'
-
 defineEmits<{ close: [] }>()
-
-const shortcuts = [
-  { keys: `${mod}N`, description: 'New document' },
-  { keys: `${mod}O`, description: 'Open document' },
-  { keys: `${mod}I`, description: 'Document info' },
-  { keys: `${mod}⇧P`, description: 'Publish' },
-  { keys: 'F1', description: 'Show this help' },
-  { keys: 'Tab', description: 'Insert tab character' },
-  { keys: 'Esc', description: 'Close modal' },
-]
 </script>
 
 <template>
@@ -36,21 +23,6 @@ const shortcuts = [
         class="docs-link"
       >See which syntax is available →</a>
     </p>
-
-    <h3 class="section-title">
-      Keyboard shortcuts
-    </h3>
-    <table class="shortcuts">
-      <tbody>
-        <tr
-          v-for="s in shortcuts"
-          :key="s.keys"
-        >
-          <td><kbd>{{ s.keys }}</kbd></td>
-          <td>{{ s.description }}</td>
-        </tr>
-      </tbody>
-    </table>
   </BaseModal>
 </template>
 
@@ -72,38 +44,4 @@ const shortcuts = [
   text-decoration: underline;
 }
 
-.section-title {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--ctp-subtext0);
-  margin-bottom: 0.6rem;
-}
-
-.shortcuts {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.shortcuts td {
-  padding: 0.35rem 0;
-  font-size: 0.88rem;
-  color: var(--ctp-subtext1);
-  vertical-align: middle;
-}
-
-.shortcuts td:first-child {
-  width: 6rem;
-}
-
-kbd {
-  font-family: inherit;
-  font-size: 0.75rem;
-  padding: 0.15em 0.4em;
-  border: 1px solid var(--ctp-surface1);
-  border-radius: 3px;
-  background: var(--ctp-surface0);
-  color: var(--ctp-subtext0);
-}
 </style>


### PR DESCRIPTION
The menubar shortcut hints and keyboard bindings were causing inconsistent behavior across browsers and operating systems. This removes that platform-sensitive shortcut surface so the UI behaves the same way everywhere.

## What changed
- Removed the cursor-following shortcut tooltip logic and rendering from `AppMenuBar`.
- Removed app-level keyboard shortcut handlers (`Cmd/Ctrl+N`, `Cmd/Ctrl+O`, `Cmd/Ctrl+Shift+P`, `F1`) from `App.vue`.
- Removed the keyboard shortcuts table from the Help modal so it no longer documents removed shortcuts.

## Notes for reviewers
- This is intentionally a subtraction-only change: actions remain accessible through the menubar buttons and modals.