### PR TITLE
Decouple metadata editing from publish flow

### DIFF
--- a/app/api/src/__tests__/createDraft.test.ts
+++ b/app/api/src/__tests__/createDraft.test.ts
@@ -59,6 +59,14 @@ const CREATED_DOC = {
   slug: { _type: 'slug', current: 'my-post' },
 }
 
+function makeCreateClient(options?: { slugConflictId?: string | null; createThrows?: unknown }) {
+  const fetch = vi.fn().mockResolvedValue(options?.slugConflictId ?? null)
+  const create = options?.createThrows
+    ? vi.fn().mockRejectedValue(options.createThrows)
+    : vi.fn().mockResolvedValue(CREATED_DOC)
+  return { fetch, create }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('createDraft handler', () => {
@@ -112,8 +120,8 @@ describe('createDraft handler', () => {
   })
 
   it('creates a draft with a "drafts." prefixed ID', async () => {
-    const create = vi.fn().mockResolvedValue(CREATED_DOC)
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    const { fetch, create } = makeCreateClient()
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
 
@@ -122,8 +130,8 @@ describe('createDraft handler', () => {
   })
 
   it('creates a draft with correct type, title, and slug', async () => {
-    const create = vi.fn().mockResolvedValue(CREATED_DOC)
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    const { fetch, create } = makeCreateClient()
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
 
@@ -137,8 +145,8 @@ describe('createDraft handler', () => {
   })
 
   it('trims whitespace from title and slug', async () => {
-    const create = vi.fn().mockResolvedValue(CREATED_DOC)
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    const { fetch, create } = makeCreateClient()
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     await getHandler()(makeRequest({ body: { title: '  My Post  ', slug: '  my-post  ' } }))
 
@@ -148,8 +156,8 @@ describe('createDraft handler', () => {
   })
 
   it('returns 201 with the created document', async () => {
-    const create = vi.fn().mockResolvedValue(CREATED_DOC)
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    const { fetch, create } = makeCreateClient()
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     const res = await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
 
@@ -163,9 +171,20 @@ describe('createDraft handler', () => {
     )
   })
 
+  it('returns 409 when slug is already in use for the document type', async () => {
+    const { fetch, create } = makeCreateClient({ slugConflictId: 'drafts.existing-id' })
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
+
+    const res = await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
+
+    expect(res.status).toBe(409)
+    expect(res.jsonBody).toEqual({ error: '"slug" must be unique for this content type' })
+    expect(create).not.toHaveBeenCalled()
+  })
+
   it('returns 502 when Sanity client throws', async () => {
-    const create = vi.fn().mockRejectedValue(new Error('Sanity create failed'))
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    const { fetch, create } = makeCreateClient({ createThrows: new Error('Sanity create failed') })
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     const res = await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
     expect(res.status).toBe(502)
@@ -173,8 +192,8 @@ describe('createDraft handler', () => {
   })
 
   it('returns 502 with generic message for non-Error throws', async () => {
-    const create = vi.fn().mockRejectedValue('string error')
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    const { fetch, create } = makeCreateClient({ createThrows: 'string error' })
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     const res = await getHandler()(makeRequest({ body: { title: 'My Post', slug: 'my-post' } }))
     expect(res.status).toBe(502)
@@ -214,8 +233,9 @@ describe('createDraft handler – custom schema mapping', () => {
   })
 
   it('creates a draft with the configured document type', async () => {
+    const fetch = vi.fn().mockResolvedValue(null)
     const create = vi.fn().mockResolvedValue({ _id: 'drafts.test-id', _type: 'article' })
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     await getHandler()(makeRequest({ body: { title: 'My Article', slug: 'my-article', documentType: 'article' } }))
 
@@ -224,8 +244,9 @@ describe('createDraft handler – custom schema mapping', () => {
   })
 
   it('uses configured title and slug field names', async () => {
+    const fetch = vi.fn().mockResolvedValue(null)
     const create = vi.fn().mockResolvedValue({ _id: 'drafts.test-id', _type: 'article' })
-    vi.mocked(getSanityClient).mockReturnValue({ create } as any)
+    vi.mocked(getSanityClient).mockReturnValue({ fetch, create } as any)
 
     await getHandler()(makeRequest({ body: { title: 'My Article', slug: 'my-article' } }))
 

--- a/app/api/src/__tests__/saveDocument.test.ts
+++ b/app/api/src/__tests__/saveDocument.test.ts
@@ -53,8 +53,9 @@ function makePatchClient(opts?: { commitThrows?: boolean }) {
     : vi.fn().mockResolvedValue({ transactionId: 'tx-123' })
   const set = vi.fn().mockReturnValue({ commit })
   const patch = vi.fn().mockReturnValue({ set })
+  const fetch = vi.fn().mockResolvedValue(null)
   const getDocument = vi.fn().mockResolvedValue({ _id: 'drafts.550e8400-e29b-41d4-a716-446655440000', _type: 'blog' })
-  return { patch, set, commit, getDocument }
+  return { patch, set, commit, fetch, getDocument }
 }
 
 const VALID_PRINCIPAL = {
@@ -118,8 +119,8 @@ describe('saveDocument handler', () => {
   })
 
   it('saves blocks without title and returns 204', async () => {
-    const { patch, set, commit, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, commit, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks } }))
@@ -131,8 +132,8 @@ describe('saveDocument handler', () => {
   })
 
   it('saves blocks with title and returns 204', async () => {
-    const { patch, set, commit, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, commit, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks, title: 'My Post' } }))
@@ -143,8 +144,8 @@ describe('saveDocument handler', () => {
   })
 
   it('does not include title field when title is undefined', async () => {
-    const { patch, set, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks: [] } }))
 
@@ -153,8 +154,8 @@ describe('saveDocument handler', () => {
   })
 
   it('saves title without blocks and returns 204', async () => {
-    const { patch, set, commit, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, commit, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { title: 'Updated Title' } }))
 
@@ -165,8 +166,8 @@ describe('saveDocument handler', () => {
   })
 
   it('does not include body field when blocks is undefined', async () => {
-    const { patch, set, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { title: 'Only Title' } }))
 
@@ -175,9 +176,36 @@ describe('saveDocument handler', () => {
     expect(setArg).toHaveProperty('title', 'Only Title')
   })
 
+  it('returns 409 when metadata slug conflicts within the same content type', async () => {
+    const { patch, fetch, getDocument } = makePatchClient()
+    fetch.mockResolvedValue('drafts.existing-id')
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
+
+    const res = await getHandler()(makeRequest({
+      params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
+      body: { metadata: { slug: 'my-post' } },
+    }))
+
+    expect(res.status).toBe(409)
+    expect(res.jsonBody).toEqual({ error: '"slug" must be unique for this content type' })
+  })
+
+  it('returns 400 when metadata slug is empty', async () => {
+    const { patch, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
+
+    const res = await getHandler()(makeRequest({
+      params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
+      body: { metadata: { slug: '   ' } },
+    }))
+
+    expect(res.status).toBe(400)
+    expect(res.jsonBody).toEqual({ error: '"slug" is required' })
+  })
+
   it('returns 502 when Sanity client throws', async () => {
-    const { patch, getDocument } = makePatchClient({ commitThrows: true })
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, fetch, getDocument } = makePatchClient({ commitThrows: true })
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     const res = await getHandler()(makeRequest({ params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' }, body: { blocks: [] } }))
 
@@ -189,8 +217,10 @@ describe('saveDocument handler', () => {
     const commit = vi.fn().mockRejectedValue('string error')
     const set = vi.fn().mockReturnValue({ commit })
     const patch = vi.fn().mockReturnValue({ set })
+    const fetch = vi.fn().mockResolvedValue(null)
     vi.mocked(getSanityClient).mockReturnValue({
       patch,
+      fetch,
       getDocument: vi.fn().mockResolvedValue({ _id: 'drafts.550e8400-e29b-41d4-a716-446655440000', _type: 'blog' }),
     } as any)
 
@@ -233,8 +263,8 @@ describe('saveDocument handler – custom schema mapping', () => {
   })
 
   it('uses the configured body field name when saving blocks', async () => {
-    const { patch, set, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     await getHandler()(makeRequest({
@@ -246,8 +276,8 @@ describe('saveDocument handler – custom schema mapping', () => {
   })
 
   it('uses the configured title field name when saving title', async () => {
-    const { patch, set, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     await getHandler()(makeRequest({
       params: { id: 'drafts.550e8400-e29b-41d4-a716-446655440000' },
@@ -258,8 +288,8 @@ describe('saveDocument handler – custom schema mapping', () => {
   })
 
   it('uses both configured field names when saving blocks and title together', async () => {
-    const { patch, set, getDocument } = makePatchClient()
-    vi.mocked(getSanityClient).mockReturnValue({ patch, getDocument } as any)
+    const { patch, set, fetch, getDocument } = makePatchClient()
+    vi.mocked(getSanityClient).mockReturnValue({ patch, fetch, getDocument } as any)
 
     const blocks = [{ _type: 'block', children: [] }]
     await getHandler()(makeRequest({

--- a/app/api/src/functions/createDraft.ts
+++ b/app/api/src/functions/createDraft.ts
@@ -5,6 +5,7 @@ import {
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { getApiRuntimeConfig, getContentTypeConfig } from '../config/runtime.js'
+import { findSlugConflictId } from '../slugUniqueness.js'
 
 app.http('createDraft', {
   methods: ['POST'],
@@ -40,12 +41,21 @@ app.http('createDraft', {
       }
       const typeConfig = getContentTypeConfig(requestedType)
       const client = getSanityClient()
+      const normalizedSlug = body.slug.trim()
+      const existingSlugId = await findSlugConflictId(client, {
+        documentType: typeConfig.name,
+        slugField: typeConfig.slugField,
+        slug: normalizedSlug,
+      })
+      if (existingSlugId) {
+        return { status: 409, jsonBody: { error: '"slug" must be unique for this content type' } }
+      }
       const id = `${config.content.draftPrefix}${crypto.randomUUID()}`
       const createPayload: Record<string, unknown> = {
         _id: id,
         _type: typeConfig.name,
         [typeConfig.titleField]: body.title.trim(),
-        [typeConfig.slugField]: { _type: 'slug', current: body.slug.trim() },
+        [typeConfig.slugField]: { _type: 'slug', current: normalizedSlug },
       }
       const doc = await client.create(createPayload as Parameters<typeof client.create>[0])
       return {

--- a/app/api/src/functions/saveDocument.ts
+++ b/app/api/src/functions/saveDocument.ts
@@ -4,7 +4,13 @@ import {
   type HttpResponseInit,
 } from '@azure/functions'
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
-import { getApiRuntimeConfig, getContentTypeConfig, type MetadataFieldConfig } from '../config/runtime.js'
+import {
+  getApiRuntimeConfig,
+  getContentTypeConfig,
+  toPublishedDocumentId,
+  type MetadataFieldConfig,
+} from '../config/runtime.js'
+import { findSlugConflictId } from '../slugUniqueness.js'
 
 function normalizeMetadataFieldValue(
   field: MetadataFieldConfig,
@@ -20,6 +26,9 @@ function normalizeMetadataFieldValue(
     case 'slug':
       if (typeof value !== 'string') {
         throw new Error(`"${field.key}" must be a string`)
+      }
+      if (!value.trim()) {
+        throw new Error(`"${field.key}" is required`)
       }
       return { _type: 'slug', current: value.trim() }
     case 'stringArray':
@@ -107,6 +116,7 @@ app.http('saveDocument', {
       }
       const typeConfig = getContentTypeConfig(existing._type)
       const fields: Record<string, unknown> = {}
+      let slugForUniquenessCheck: string | null = null
       if (Array.isArray(body.blocks)) {
         fields[typeConfig.bodyField] = body.blocks
       }
@@ -121,13 +131,31 @@ app.http('saveDocument', {
             return { status: 400, jsonBody: { error: `"metadata.${key}" is not configured for this type` } }
           }
           try {
-            fields[field.field] = normalizeMetadataFieldValue(field, value)
+            const normalized = normalizeMetadataFieldValue(field, value)
+            fields[field.field] = normalized
+            if (field.type === 'slug' && typeof normalized === 'object' && normalized !== null && 'current' in normalized) {
+              const current = normalized.current
+              if (typeof current === 'string') {
+                slugForUniquenessCheck = current
+              }
+            }
           } catch (error) {
             return {
               status: 400,
               jsonBody: { error: error instanceof Error ? error.message : `Invalid value for "${key}"` },
             }
           }
+        }
+      }
+      if (slugForUniquenessCheck) {
+        const conflictId = await findSlugConflictId(client, {
+          documentType: typeConfig.name,
+          slugField: typeConfig.slugField,
+          slug: slugForUniquenessCheck,
+          excludeIds: [id, toPublishedDocumentId(id)],
+        })
+        if (conflictId) {
+          return { status: 409, jsonBody: { error: '"slug" must be unique for this content type' } }
         }
       }
       await client.patch(id).set(fields).commit()

--- a/app/api/src/slugUniqueness.ts
+++ b/app/api/src/slugUniqueness.ts
@@ -1,0 +1,33 @@
+import type { SanityClient } from '@sanity/client'
+
+interface SlugLookupOptions {
+  documentType: string
+  slugField: string
+  slug: string
+  excludeIds?: string[]
+}
+
+const FIELD_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+export async function findSlugConflictId(
+  client: SanityClient,
+  options: SlugLookupOptions,
+): Promise<string | null> {
+  const slugField = options.slugField.trim()
+  if (!FIELD_NAME_RE.test(slugField)) {
+    throw new Error(`Invalid slug field name: ${options.slugField}`)
+  }
+
+  const query = `*[
+    _type == $documentType
+    && ${slugField}.current == $slug
+    && !(_id in $excludeIds)
+  ][0]._id`
+
+  const conflict = await client.fetch<string | null>(query, {
+    documentType: options.documentType,
+    slug: options.slug,
+    excludeIds: options.excludeIds ?? [],
+  })
+  return conflict ?? null
+}

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -18,7 +18,12 @@ const showOpen = ref(false)
 const showNew = ref(false)
 const showHelp = ref(false)
 const showSettings = ref(false)
+const showMetadataModal = ref(false)
 const showPublishModal = ref(false)
+const metadataError = ref('')
+const publishError = ref('')
+const metadataSubmitting = ref(false)
+const publishSubmitting = ref(false)
 const editorStore = useEditorStore()
 const auth = useAuthStore()
 const draftPrefix = runtimeConfig.content.draftPrefix
@@ -59,6 +64,12 @@ const canPublish = computed(() =>
   && editorStore.publishStatus !== 'publishing',
 )
 
+const canEditMetadata = computed(() =>
+  auth.isAuthenticated
+  && !!editorStore.activeDocument
+  && editorStore.publishStatus !== 'publishing',
+)
+
 const isDraft = computed(() =>
   !!editorStore.activeDocument
   && editorStore.activeDocument._id.startsWith(draftPrefix),
@@ -74,25 +85,70 @@ function onNewDocument() {
 
 async function publishDocument() {
   if (!canPublish.value) return
+  publishError.value = ''
   showPublishModal.value = true
 }
 
-async function onPublishConfirm(meta: DocumentMeta) {
-  showPublishModal.value = false
+function openMetadataModal() {
+  if (!canEditMetadata.value) return
+  metadataError.value = ''
+  showMetadataModal.value = true
+}
+
+function isPersistableDraft(id: string): boolean {
+  return id.startsWith(draftPrefix)
+}
+
+function toMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message
+  return fallback
+}
+
+async function persistMetadata(meta: DocumentMeta): Promise<void> {
   const doc = editorStore.activeDocument
-  if (!doc) return
+  if (!doc || !auth.isAuthenticated || !isPersistableDraft(doc._id)) return
+  await apiSaveDocument(doc._id, undefined, meta.title, editorStore.metadataPayload())
+}
+
+async function onMetadataSubmit(meta: DocumentMeta) {
+  metadataError.value = ''
+  metadataSubmitting.value = true
+  editorStore.updateMeta(meta)
+  try {
+    await persistMetadata(meta)
+    showMetadataModal.value = false
+  } catch (err) {
+    metadataError.value = toMessage(err, 'Failed to save metadata')
+    trackException(err instanceof Error ? err : new Error(String(err)), { action: 'save_metadata' })
+  } finally {
+    metadataSubmitting.value = false
+  }
+}
+
+async function onPublishConfirm(meta: DocumentMeta) {
+  publishError.value = ''
+  publishSubmitting.value = true
+  const doc = editorStore.activeDocument
+  if (!doc) {
+    publishSubmitting.value = false
+    return
+  }
 
   editorStore.updateMeta(meta)
 
   try {
     // Save metadata updates to Sanity before publishing
-    await apiSaveDocument(doc._id, undefined, meta.title, editorStore.metadataPayload())
+    await persistMetadata(meta)
   } catch (err) {
     console.error('[publish] pre-publish save failed:', err)
+    publishError.value = toMessage(err, 'Failed to save metadata before publish')
+    publishSubmitting.value = false
     trackException(err instanceof Error ? err : new Error(String(err)), { action: 'pre_publish_save' })
     return
   }
 
+  showPublishModal.value = false
+  publishSubmitting.value = false
   await doPublish()
 }
 
@@ -135,10 +191,12 @@ onMounted(async () => {
     :user="auth.user ?? undefined"
     :is-authenticated="auth.isAuthenticated"
     :has-document="!!editorStore.activeDocument"
+    :can-edit-metadata="canEditMetadata"
     :can-publish="canPublish"
     :is-draft="isDraft"
     @new="onNewDocument"
     @open="showOpen = true"
+    @metadata="openMetadataModal"
     @publish="publishDocument"
     @help="showHelp = true"
     @settings="showSettings = true"
@@ -165,9 +223,20 @@ onMounted(async () => {
     @close="showSettings = false"
   />
   <PublishModal
+    v-if="showMetadataModal"
+    mode="edit"
+    :is-submitting="metadataSubmitting"
+    :error-message="metadataError"
+    @close="showMetadataModal = false"
+    @submit="onMetadataSubmit"
+  />
+  <PublishModal
     v-if="showPublishModal"
+    mode="publish"
+    :is-submitting="publishSubmitting"
+    :error-message="publishError"
     @close="showPublishModal = false"
-    @publish="onPublishConfirm"
+    @submit="onPublishConfirm"
   />
 </template>
 

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   user?: AuthUser
   isAuthenticated?: boolean
   hasDocument?: boolean
+  canEditMetadata?: boolean
   canPublish?: boolean
   isDraft?: boolean
 }>()
@@ -28,7 +29,16 @@ const statusLabel = computed(() => {
   if (ss === 'error') return { text: 'Save failed', style: 'error' as const }
   return null
 })
-const emit = defineEmits<{ new: []; open: []; publish: []; help: []; settings: []; signin: []; logout: [] }>()
+const emit = defineEmits<{
+  new: []
+  open: []
+  metadata: []
+  publish: []
+  help: []
+  settings: []
+  signin: []
+  logout: []
+}>()
 
 const mobileMenuOpen = ref(false)
 const showUserModal = ref(false)
@@ -38,7 +48,7 @@ function openUserModal() {
   showUserModal.value = true
 }
 
-function mobileEmit(event: 'new' | 'open' | 'publish' | 'help' | 'settings' | 'signin' | 'logout') {
+function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 'settings' | 'signin' | 'logout') {
   mobileMenuOpen.value = false
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   emit(event as any)
@@ -142,6 +152,19 @@ function mobileEmit(event: 'new' | 'open' | 'publish' | 'help' | 'settings' | 's
           @click="isAuthenticated && $emit('open')"
         >
           Open
+        </button>
+        <span
+          class="menubar__sep"
+          aria-hidden="true"
+        />
+        <button
+          role="menuitem"
+          class="menubar__item"
+          :class="{ 'menubar__item--disabled': !canEditMetadata }"
+          :disabled="!canEditMetadata"
+          @click="canEditMetadata && $emit('metadata')"
+        >
+          Metadata
         </button>
         <span
           class="menubar__sep"
@@ -328,6 +351,15 @@ function mobileEmit(event: 'new' | 'open' | 'publish' | 'help' | 'settings' | 's
           @click="isAuthenticated && mobileEmit('open')"
         >
           Open
+        </button>
+        <button
+          role="menuitem"
+          class="menubar__mobile-item"
+          :class="{ 'menubar__item--disabled': !canEditMetadata }"
+          :disabled="!canEditMetadata"
+          @click="canEditMetadata && mobileEmit('metadata')"
+        >
+          Metadata
         </button>
         <button
           role="menuitem"

--- a/app/src/components/PublishModal.vue
+++ b/app/src/components/PublishModal.vue
@@ -4,14 +4,28 @@ import BaseModal from './BaseModal.vue'
 import { useEditorStore, type DocumentMeta } from '../stores/editor'
 import { getContentTypeConfig } from '../config/runtime'
 
+const props = withDefaults(defineProps<{
+  mode: 'edit' | 'publish'
+  isSubmitting?: boolean
+  errorMessage?: string
+}>(), {
+  isSubmitting: false,
+  errorMessage: '',
+})
+
 const emit = defineEmits<{
   close: []
-  publish: [meta: DocumentMeta]
+  submit: [meta: DocumentMeta]
 }>()
 
 const store = useEditorStore()
 const typeConfig = computed(() => getContentTypeConfig(store.meta.documentType))
 const fields = computed(() => typeConfig.value.metadataFields)
+const isPublishMode = computed(() => props.mode === 'publish')
+const actionLabel = computed(() => (isPublishMode.value ? 'Publish' : 'Save metadata'))
+const modalTitle = computed(() => (isPublishMode.value
+  ? `Publish — ${typeConfig.value.label}`
+  : `Metadata — ${typeConfig.value.label}`))
 
 const values = reactive<Record<string, unknown>>({})
 for (const field of fields.value) {
@@ -31,6 +45,13 @@ watch(
 )
 
 function onSlugInput() {
+  slugManuallyEdited.value = true
+}
+
+function generateSlug() {
+  const title = values['title']
+  if (typeof title !== 'string') return
+  values['slug'] = store.slugify(title)
   slugManuallyEdited.value = true
 }
 
@@ -114,15 +135,15 @@ function formatDateTimeValue(value: unknown): string {
   return value.slice(0, 16)
 }
 
-function saveAndPublish() {
+function submit() {
   if (!canPublish.value) return
-  emit('publish', buildMeta())
+  emit('submit', buildMeta())
 }
 </script>
 
 <template>
   <BaseModal
-    :title="`Metadata — ${typeConfig.label}`"
+    :title="modalTitle"
     @close="emit('close')"
   >
     <div class="publish-modal">
@@ -137,16 +158,29 @@ function saveAndPublish() {
         >
           {{ field.label }}<span v-if="field.required"> *</span>
         </label>
-        <input
+        <div
           v-if="field.type === 'string' || field.type === 'slug'"
-          :id="`meta-${field.key}`"
-          v-model="values[field.key]"
-          class="field__input"
-          :class="{ 'field__input--mono': field.type === 'slug' }"
-          type="text"
-          :placeholder="field.type === 'slug' ? 'auto-generated-from-title' : ''"
-          @input="field.type === 'slug' && onSlugInput()"
+          class="field__input-row"
         >
+          <input
+            :id="`meta-${field.key}`"
+            v-model="values[field.key]"
+            class="field__input"
+            :class="{ 'field__input--mono': field.type === 'slug' }"
+            type="text"
+            :placeholder="field.type === 'slug' ? 'auto-generated-from-title' : ''"
+            @input="field.type === 'slug' && onSlugInput()"
+          >
+          <button
+            v-if="field.type === 'slug'"
+            type="button"
+            class="btn btn--ghost btn--compact"
+            :disabled="isSubmitting"
+            @click="generateSlug"
+          >
+            Generate slug
+          </button>
+        </div>
         <input
           v-else-if="field.type === 'datetime'"
           :id="`meta-${field.key}`"
@@ -176,20 +210,27 @@ function saveAndPublish() {
           <span>Enabled</span>
         </label>
       </div>
+      <p
+        v-if="errorMessage"
+        class="error"
+      >
+        {{ errorMessage }}
+      </p>
 
       <div class="actions">
         <button
           class="btn btn--ghost"
+          :disabled="isSubmitting"
           @click="emit('close')"
         >
           Cancel
         </button>
         <button
           class="btn btn--primary"
-          :disabled="!canPublish"
-          @click="saveAndPublish"
+          :disabled="!canPublish || isSubmitting"
+          @click="submit"
         >
-          Publish
+          {{ isSubmitting ? 'Saving…' : actionLabel }}
         </button>
       </div>
     </div>
@@ -207,6 +248,12 @@ function saveAndPublish() {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.field__input-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 .field__label {
@@ -229,6 +276,10 @@ function saveAndPublish() {
   width: 100%;
   box-sizing: border-box;
   color-scheme: dark;
+}
+
+.field__input-row .field__input {
+  flex: 1;
 }
 
 .field__input:focus {
@@ -255,6 +306,12 @@ function saveAndPublish() {
   margin-top: 0.25rem;
 }
 
+.error {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--ctp-red);
+}
+
 .btn {
   padding: 0.4rem 0.9rem;
   border-radius: 6px;
@@ -262,6 +319,12 @@ function saveAndPublish() {
   cursor: pointer;
   border: 1px solid transparent;
   transition: background 0.15s ease, color 0.15s ease;
+}
+
+.btn--compact {
+  font-size: 0.78rem;
+  padding: 0.35rem 0.65rem;
+  white-space: nowrap;
 }
 
 .btn:disabled {


### PR DESCRIPTION
## Why
Metadata editing was only available as part of the publish action. That made routine metadata updates awkward and tightly coupled authoring metadata with publishing. Slug values are also URL-facing, so they must remain unique within each schema type.

## What changed
- Added a dedicated **Metadata** action in the top menu (desktop and mobile), separate from **Publish**.
- Kept publish confirmation as a final step, but made it use the same pre-populated metadata form state.
- Updated the metadata/publish modal flow to support both edit mode and publish-confirm mode.
- Added a **Generate slug** button in both metadata edit and publish confirmation flows.
- Persist metadata changes immediately for authenticated draft documents.
- Added schema-type slug uniqueness enforcement in API create/save paths, with clear conflict errors.
- Added a shared API helper for slug conflict lookup and updated tests for create/save conflict behavior.

## Notes for review
- Slug uniqueness checks are scoped to `documentType` and exclude the current document (and its published counterpart) during edits.
- Publish remains a confirmation flow, but metadata is now independently editable at any time.