### PR TITLE
fix: top fade overlap at document start

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -501,7 +501,7 @@ watch(
 /* Long-form content: top-aligned with typewriter bottom padding */
 .editor--long-content {
   justify-content: flex-start;
-  padding-top: var(--space-2xl);
+  padding-top: var(--space-3xl);
   padding-bottom: 50vh;
 }
 


### PR DESCRIPTION
## Why
When a long document is scrolled to the top, the title and first lines sit too close to the viewport top and get overly faded by the fixed focus overlay.

## What changed
The long-content layout now uses a larger top inset so initial content starts lower in the viewport:
- Updated `.editor--long-content` `padding-top` from `var(--space-2xl)` to `var(--space-3xl)`.
- Kept `.focus-fade` unchanged so content still fades near the top as users continue scrolling.

## Notes
This uses existing spacing tokens and applies only in long-content mode.