### PR TITLE
fix: show title and writing cue after creating draft

### DIFF
--- a/app/src/components/NewDocumentModal.vue
+++ b/app/src/components/NewDocumentModal.vue
@@ -16,19 +16,22 @@ const title = ref('')
 const selectedType = ref(editorStore.meta.documentType || runtimeConfig.content.defaultType)
 const creating = ref(false)
 const error = ref<string | null>(null)
+const NEW_DRAFT_START_PLACEHOLDER = 'Start writing here…'
 
 // ── Slug derivation ───────────────────────────────────────────────────────────
 const slug = computed(() => editorStore.slugify(title.value))
 
 // ── Create ────────────────────────────────────────────────────────────────────
 async function create() {
-  if (!title.value.trim()) return
+  const trimmedTitle = title.value.trim()
+  if (!trimmedTitle) return
 
   creating.value = true
   error.value = null
   try {
-    const doc = await apiCreateDraft(title.value.trim(), slug.value, selectedType.value)
-    editorStore.openDocument(doc, '<p></p>')
+    const doc = await apiCreateDraft(trimmedTitle, slug.value, selectedType.value)
+    const initialHtml = `<h1 data-type="title">${escapeHtml(trimmedTitle)}</h1><p data-start-placeholder="${escapeHtml(NEW_DRAFT_START_PLACEHOLDER)}"></p>`
+    editorStore.openDocument(doc, initialHtml)
     emit('created')
     emit('close')
   } catch (e: unknown) {
@@ -43,6 +46,14 @@ function onKeydown(e: KeyboardEvent) {
     e.preventDefault()
     create()
   }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 </script>
 

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -566,6 +566,28 @@ watch(
   margin-bottom: 0;
 }
 
+.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:empty) {
+  min-height: 1.4em;
+}
+
+.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:empty::before) {
+  content: attr(data-start-placeholder);
+  color: var(--ctp-subtext0);
+  pointer-events: none;
+}
+
+.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:empty::after) {
+  content: '';
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin: 0 0.24em;
+  background: var(--ctp-mauve);
+  border-radius: 2px;
+  vertical-align: -0.12em;
+  animation: start-caret-blink 1s steps(2, start) infinite;
+}
+
 /* ── Title node ───────────────────────────────────────────────────────────── */
 .editor__content :deep(.ProseMirror h1[data-type='title']) {
   font-size: 2em;
@@ -744,6 +766,17 @@ watch(
 
 .focus-fade--active {
   opacity: 1;
+}
+
+@keyframes start-caret-blink {
+  0%,
+  48% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
 }
 
 /* ── Block inserter "+" button ────────────────────────────────────────────── */


### PR DESCRIPTION
Creating a new draft currently opens into what looks like an empty canvas, even though the user just entered a title. This makes the first-edit experience feel broken and leaves no obvious starting point.

## What changed
- New draft initialization now seeds valid editor content with the entered title as the title node (`h1[data-type="title"]`) instead of opening with only an empty paragraph.
- Added a dedicated first-paragraph writing cue for newly created drafts using `data-start-placeholder` with the copy `Start writing here...`.
- Added a visible inline marker next to that cue so the insertion point is easier to spot before typing.
- Tuned the perceived caret visibility in the entry state with a slightly thicker marker and subtle horizontal spacing.

## Notes for review
- This only affects the post-`Create draft` flow from `NewDocumentModal`.
- Existing intro/reset placeholder behavior remains unchanged.