### PR TITLE
fix: show helper text in empty first body paragraph

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -566,17 +566,17 @@ watch(
   margin-bottom: 0;
 }
 
-.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:empty) {
+.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:is(:empty, :has(> br.ProseMirror-trailingBreak:only-child))) {
   min-height: 1.4em;
 }
 
-.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:empty::before) {
+.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:is(:empty, :has(> br.ProseMirror-trailingBreak:only-child))::before) {
   content: attr(data-start-placeholder);
   color: var(--ctp-subtext0);
   pointer-events: none;
 }
 
-.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:empty::after) {
+.editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:is(:empty, :has(> br.ProseMirror-trailingBreak:only-child))::after) {
   content: '';
   display: inline-block;
   width: 2px;


### PR DESCRIPTION
After merging #179, the follow-up helper text did not appear in the first body paragraph because Tiptap renders an empty paragraph with a trailing break node, so the `:empty` selector did not match.

## What changed
- Updated the first-paragraph helper selectors to match both truly empty paragraphs and Tiptap paragraphs that only contain `br.ProseMirror-trailingBreak`.
- Kept the existing behavior where the helper text and marker disappear immediately when typing starts.

## Notes for review
- This is intentionally a separate follow-up PR after #179.
- Scope is limited to `HomeView.vue` selector behavior for the draft entry cue.