### PR TITLE
fix: improve block insertion and image library usability

### DIFF
--- a/app/api/src/__tests__/listImages.test.ts
+++ b/app/api/src/__tests__/listImages.test.ts
@@ -67,8 +67,20 @@ describe('listImages handler', () => {
 
   it('returns 200 with mapped image assets', async () => {
     const rawAssets = [
-      { _id: 'image-abc-800x600-jpg', url: 'https://cdn.sanity.io/a.jpg', width: 800, height: 600 },
-      { _id: 'image-def-1920x1080-png', url: 'https://cdn.sanity.io/b.png', width: 1920, height: 1080 },
+      {
+        _id: 'image-abc-800x600-jpg',
+        url: 'https://cdn.sanity.io/a.jpg',
+        width: 800,
+        height: 600,
+        createdAt: '2024-01-01T10:00:00.000Z',
+      },
+      {
+        _id: 'image-def-1920x1080-png',
+        url: 'https://cdn.sanity.io/b.png',
+        width: 1920,
+        height: 1080,
+        createdAt: '2024-01-02T10:00:00.000Z',
+      },
     ]
     vi.mocked(getSanityClient).mockReturnValue({
       fetch: vi.fn().mockResolvedValue(rawAssets),
@@ -77,8 +89,20 @@ describe('listImages handler', () => {
     const res = await getHandler()(makeRequest())
     expect(res.status).toBe(200)
     expect(res.jsonBody).toEqual([
-      { assetRef: 'image-abc-800x600-jpg', url: 'https://cdn.sanity.io/a.jpg', width: 800, height: 600 },
-      { assetRef: 'image-def-1920x1080-png', url: 'https://cdn.sanity.io/b.png', width: 1920, height: 1080 },
+      {
+        assetRef: 'image-abc-800x600-jpg',
+        url: 'https://cdn.sanity.io/a.jpg',
+        width: 800,
+        height: 600,
+        createdAt: '2024-01-01T10:00:00.000Z',
+      },
+      {
+        assetRef: 'image-def-1920x1080-png',
+        url: 'https://cdn.sanity.io/b.png',
+        width: 1920,
+        height: 1080,
+        createdAt: '2024-01-02T10:00:00.000Z',
+      },
     ])
   })
 
@@ -94,7 +118,13 @@ describe('listImages handler', () => {
 
   it('returns 200 with null dimensions when metadata is missing', async () => {
     const rawAssets = [
-      { _id: 'image-abc-800x600-jpg', url: 'https://cdn.sanity.io/a.jpg', width: null, height: null },
+      {
+        _id: 'image-abc-800x600-jpg',
+        url: 'https://cdn.sanity.io/a.jpg',
+        width: null,
+        height: null,
+        createdAt: null,
+      },
     ]
     vi.mocked(getSanityClient).mockReturnValue({
       fetch: vi.fn().mockResolvedValue(rawAssets),
@@ -103,7 +133,13 @@ describe('listImages handler', () => {
     const res = await getHandler()(makeRequest())
     expect(res.status).toBe(200)
     expect(res.jsonBody).toEqual([
-      { assetRef: 'image-abc-800x600-jpg', url: 'https://cdn.sanity.io/a.jpg', width: null, height: null },
+      {
+        assetRef: 'image-abc-800x600-jpg',
+        url: 'https://cdn.sanity.io/a.jpg',
+        width: null,
+        height: null,
+        createdAt: null,
+      },
     ])
   })
 

--- a/app/api/src/functions/listImages.ts
+++ b/app/api/src/functions/listImages.ts
@@ -10,6 +10,7 @@ interface ImageAsset {
   url: string
   width: number | null
   height: number | null
+  createdAt: string | null
 }
 
 app.http('listImages', {
@@ -24,13 +25,14 @@ app.http('listImages', {
 
     try {
       const assets = await getSanityClient().fetch<
-        { _id: string; url: string; width: number | null; height: number | null }[]
+        { _id: string; url: string; width: number | null; height: number | null; createdAt: string | null }[]
       >(
         `*[_type == "sanity.imageAsset"] | order(coalesce(metadata.exif.DateTimeOriginal, _createdAt) desc) {
           _id,
           url,
           "width": metadata.dimensions.width,
-          "height": metadata.dimensions.height
+          "height": metadata.dimensions.height,
+          "createdAt": coalesce(metadata.exif.DateTimeOriginal, _createdAt)
         }`,
       )
 
@@ -39,6 +41,7 @@ app.http('listImages', {
         url: a.url,
         width: a.width,
         height: a.height,
+        createdAt: a.createdAt,
       }))
 
       return { status: 200, jsonBody: result }

--- a/app/src/components/ImagePickerModal.vue
+++ b/app/src/components/ImagePickerModal.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import BaseModal from './BaseModal.vue'
 import { apiUploadImage, apiListImages, type ImageAsset } from '../services/api'
+import { clampPage, paginateImages, sortLibraryImages, type ImageSortKey } from './imageLibrary'
 
 const emit = defineEmits<{
   close: []
@@ -76,6 +77,28 @@ async function uploadFile(file: File) {
 const libraryImages = ref<ImageAsset[]>([])
 const libraryLoading = ref(false)
 const libraryError = ref<string | null>(null)
+const sortBy = ref<ImageSortKey>('newest')
+const currentPage = ref(1)
+const PAGE_SIZE = 15
+
+const sortOptions: { value: ImageSortKey; label: string }[] = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'name-asc', label: 'Name A–Z' },
+  { value: 'name-desc', label: 'Name Z–A' },
+]
+
+const sortedLibraryImages = computed(() => sortLibraryImages(libraryImages.value, sortBy.value))
+const totalPages = computed(() => Math.max(1, Math.ceil(sortedLibraryImages.value.length / PAGE_SIZE)))
+const pagedLibraryImages = computed(() => paginateImages(sortedLibraryImages.value, currentPage.value, PAGE_SIZE))
+
+watch(sortBy, () => {
+  currentPage.value = 1
+})
+
+watch(totalPages, (pages) => {
+  currentPage.value = clampPage(currentPage.value, pages)
+})
 
 async function loadLibrary() {
   if (libraryImages.value.length > 0) return
@@ -92,7 +115,12 @@ async function loadLibrary() {
 
 function switchToLibrary() {
   activeTab.value = 'library'
+  currentPage.value = 1
   loadLibrary()
+}
+
+function goToPage(page: number) {
+  currentPage.value = clampPage(page, totalPages.value)
 }
 
 onMounted(() => {
@@ -187,6 +215,23 @@ onMounted(() => {
         v-else
         class="tab-panel"
       >
+        <div
+          v-if="!libraryLoading && !libraryError && libraryImages.length > 0"
+          class="library-controls"
+          role="group"
+          aria-label="Sort images"
+        >
+          <button
+            v-for="opt in sortOptions"
+            :key="opt.value"
+            class="library-sort-tab"
+            :class="{ 'library-sort-tab--active': sortBy === opt.value }"
+            @click="sortBy = opt.value"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+
         <p
           v-if="libraryLoading"
           class="status"
@@ -210,7 +255,7 @@ onMounted(() => {
           class="grid"
         >
           <button
-            v-for="img in libraryImages"
+            v-for="img in pagedLibraryImages"
             :key="img.assetRef"
             class="grid__item"
             :title="img.assetRef"
@@ -222,6 +267,27 @@ onMounted(() => {
               class="grid__thumb"
               loading="lazy"
             >
+          </button>
+        </div>
+
+        <div
+          v-if="!libraryLoading && !libraryError && libraryImages.length > PAGE_SIZE"
+          class="pagination"
+        >
+          <button
+            class="pagination__button"
+            :disabled="currentPage <= 1"
+            @click="goToPage(currentPage - 1)"
+          >
+            Previous
+          </button>
+          <span class="pagination__status">Page {{ currentPage }} of {{ totalPages }}</span>
+          <button
+            class="pagination__button"
+            :disabled="currentPage >= totalPages"
+            @click="goToPage(currentPage + 1)"
+          >
+            Next
           </button>
         </div>
       </div>
@@ -272,6 +338,38 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.library-controls {
+  display: flex;
+  gap: 2px;
+  background: var(--ctp-surface0);
+  border-radius: 7px;
+  padding: 3px;
+}
+
+.library-sort-tab {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--ctp-subtext1);
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.3rem 0.4rem;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+
+.library-sort-tab:hover:not(.library-sort-tab--active) {
+  color: var(--ctp-text);
+  background: color-mix(in srgb, var(--ctp-surface1) 60%, transparent);
+}
+
+.library-sort-tab--active {
+  background: var(--ctp-surface2);
+  color: var(--ctp-text);
 }
 
 .drop-zone {
@@ -346,28 +444,23 @@ onMounted(() => {
 /* ── Library grid ── */
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.5rem;
-  max-height: 320px;
-  overflow-y: auto;
+  max-height: 440px;
+  overflow: hidden;
 }
 
 .grid__item {
-  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
   background: var(--ctp-surface0);
   border: 2px solid transparent;
   border-radius: 6px;
   cursor: pointer;
   overflow: hidden;
   padding: 0;
-  min-width: 0;
   transition: border-color 0.15s ease;
-}
-
-.grid__item::before {
-  content: '';
-  display: block;
-  padding-bottom: 100%;
 }
 
 .grid__item:hover {
@@ -375,11 +468,10 @@ onMounted(() => {
 }
 
 .grid__thumb {
-  position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
 }
 
 /* ── Status / error ── */
@@ -395,5 +487,32 @@ onMounted(() => {
   color: var(--ctp-red);
   font-size: 0.85rem;
   margin: 0;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.pagination__button {
+  background: var(--ctp-surface0);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 6px;
+  color: var(--ctp-text);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+}
+
+.pagination__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pagination__status {
+  color: var(--ctp-subtext0);
+  font-size: 0.8rem;
 }
 </style>

--- a/app/src/components/__tests__/imageLibrary.test.ts
+++ b/app/src/components/__tests__/imageLibrary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { clampPage, paginateImages, sortLibraryImages, type ImageSortKey } from '../imageLibrary'
+import type { ImageAsset } from '../../services/api'
+
+function makeImage(assetRef: string, createdAt: string): ImageAsset {
+  return {
+    assetRef,
+    url: `https://cdn.sanity.io/${assetRef}.jpg`,
+    width: 100,
+    height: 100,
+    createdAt,
+  }
+}
+
+describe('sortLibraryImages', () => {
+  const images = [
+    makeImage('image-c', '2024-01-03T12:00:00.000Z'),
+    makeImage('image-a', '2024-01-01T12:00:00.000Z'),
+    makeImage('image-b', '2024-01-02T12:00:00.000Z'),
+  ]
+
+  it.each([
+    ['newest', ['image-c', 'image-b', 'image-a']],
+    ['oldest', ['image-a', 'image-b', 'image-c']],
+    ['name-asc', ['image-a', 'image-b', 'image-c']],
+    ['name-desc', ['image-c', 'image-b', 'image-a']],
+  ] as [ImageSortKey, string[]][])('sorts %s as expected', (sortKey, expected) => {
+    const sorted = sortLibraryImages(images, sortKey).map((item) => item.assetRef)
+    expect(sorted).toEqual(expected)
+  })
+})
+
+describe('pagination helpers', () => {
+  it('clamps page between 1 and totalPages', () => {
+    expect(clampPage(0, 3)).toBe(1)
+    expect(clampPage(2, 3)).toBe(2)
+    expect(clampPage(5, 3)).toBe(3)
+  })
+
+  it('paginates images based on page and size', () => {
+    const images = Array.from({ length: 20 }, (_, i) => makeImage(`image-${i + 1}`, '2024-01-01T00:00:00.000Z'))
+    const page2 = paginateImages(images, 2, 15)
+    expect(page2.map((item) => item.assetRef)).toEqual(['image-16', 'image-17', 'image-18', 'image-19', 'image-20'])
+  })
+})

--- a/app/src/components/imageLibrary.ts
+++ b/app/src/components/imageLibrary.ts
@@ -1,0 +1,47 @@
+import type { ImageAsset } from '../services/api'
+
+export type ImageSortKey = 'newest' | 'oldest' | 'name-asc' | 'name-desc'
+
+function imageTimestamp(asset: ImageAsset): number {
+  if (!asset.createdAt) return Number.NaN
+  const timestamp = Date.parse(asset.createdAt)
+  return Number.isFinite(timestamp) ? timestamp : Number.NaN
+}
+
+function compareAssetRefAsc(a: ImageAsset, b: ImageAsset): number {
+  return a.assetRef.localeCompare(b.assetRef)
+}
+
+export function sortLibraryImages(images: ImageAsset[], sortBy: ImageSortKey): ImageAsset[] {
+  const list = [...images]
+
+  if (sortBy === 'name-asc') {
+    return list.sort(compareAssetRefAsc)
+  }
+
+  if (sortBy === 'name-desc') {
+    return list.sort((a, b) => compareAssetRefAsc(b, a))
+  }
+
+  const sortedByDateDesc = list.sort((a, b) => {
+    const aTime = imageTimestamp(a)
+    const bTime = imageTimestamp(b)
+    if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
+    if (Number.isNaN(aTime)) return 1
+    if (Number.isNaN(bTime)) return -1
+    return bTime - aTime
+  })
+
+  if (sortBy === 'oldest') return [...sortedByDateDesc].reverse()
+  return sortedByDateDesc
+}
+
+export function clampPage(page: number, totalPages: number): number {
+  if (totalPages <= 0) return 1
+  return Math.max(1, Math.min(page, totalPages))
+}
+
+export function paginateImages(images: ImageAsset[], page: number, pageSize: number): ImageAsset[] {
+  const start = (page - 1) * pageSize
+  return images.slice(start, start + pageSize)
+}

--- a/app/src/extensions/BlockInserter.ts
+++ b/app/src/extensions/BlockInserter.ts
@@ -7,9 +7,23 @@ const pluginKey = new PluginKey('block-inserter')
 /** Dispatched on the editor DOM when the user clicks the "+" button. */
 export const BLOCK_INSERTER_EVENT = 'block-inserter:open'
 
+interface BlockInserterContext {
+  parentTypeName: string
+  depth: number
+  isCollapsed: boolean
+}
+
+export function shouldShowBlockInserter(context: BlockInserterContext): boolean {
+  return (
+    context.parentTypeName === 'paragraph'
+    && context.depth === 1
+    && context.isCollapsed
+  )
+}
+
 /**
  * Renders a "+" widget decoration in the left margin whenever the cursor sits
- * on an empty top-level paragraph. Clicking it dispatches a
+ * on a top-level paragraph. Clicking it dispatches a
  * `block-inserter:open` CustomEvent on the editor DOM element.
  */
 export const BlockInserter = Extension.create({
@@ -24,10 +38,13 @@ export const BlockInserter = Extension.create({
             const { doc, selection } = state
             const { $head } = selection
 
-            // Only show on empty top-level paragraphs (depth 1 = direct child of doc)
-            if ($head.parent.type.name !== 'paragraph') return DecorationSet.empty
-            if ($head.depth !== 1) return DecorationSet.empty
-            if ($head.parent.content.size !== 0) return DecorationSet.empty
+            if (!shouldShowBlockInserter({
+              parentTypeName: $head.parent.type.name,
+              depth: $head.depth,
+              isCollapsed: selection.empty,
+            })) {
+              return DecorationSet.empty
+            }
 
             const pos = $head.before()
 

--- a/app/src/extensions/__tests__/BlockInserter.test.ts
+++ b/app/src/extensions/__tests__/BlockInserter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowBlockInserter } from '../BlockInserter'
+
+describe('shouldShowBlockInserter', () => {
+  it('shows inserter on a top-level paragraph with a collapsed selection', () => {
+    expect(
+      shouldShowBlockInserter({
+        parentTypeName: 'paragraph',
+        depth: 1,
+        isCollapsed: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('hides inserter outside top-level paragraphs', () => {
+    expect(
+      shouldShowBlockInserter({
+        parentTypeName: 'paragraph',
+        depth: 2,
+        isCollapsed: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldShowBlockInserter({
+        parentTypeName: 'heading',
+        depth: 1,
+        isCollapsed: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('hides inserter when selection is expanded', () => {
+    expect(
+      shouldShowBlockInserter({
+        parentTypeName: 'paragraph',
+        depth: 1,
+        isCollapsed: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -7,6 +7,7 @@ export interface ImageAsset {
   url: string
   width: number | null
   height: number | null
+  createdAt: string | null
 }
 
 export const AUTH_REDIRECT_TS_KEY = '__auth_redirect_ts'


### PR DESCRIPTION
## Why
The editor had two usability issues that made core authoring features feel broken: block insertion was discoverable only in an empty paragraph, and image library thumbnails were difficult to browse and select when many assets were present.

## What changed
- Updated the block inserter visibility logic to show the `+` control on the active top-level paragraph (collapsed selection), not only empty paragraphs.
- Added unit coverage for block inserter visibility behavior.
- Reworked the image library modal to render stable square thumbnails in a 3-column grid.
- Added image sorting controls aligned with document modal patterns: Newest, Oldest, Name A-Z, Name Z-A.
- Added pagination for the image library at 15 images per page (3x5), with previous/next navigation and page status.
- Extended image asset API shape with `createdAt` so date sorting is metadata-driven and not hardcoded in the UI.
- Updated API tests and added frontend unit tests for image sorting/pagination helpers.

## Notes for review
- The image upload progress bar width animation in `ImagePickerModal` remains unchanged intentionally; it is existing behavior and separate from the thumbnail/pagination fix.
- The API keeps returning dimensions and now includes `createdAt` from `coalesce(metadata.exif.DateTimeOriginal, _createdAt)` to support robust date sorting.