### PR TITLE
Add PRODUCT.md design context baseline

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,29 @@
+# Product
+
+## Register
+
+product
+
+## Users
+Primary users are individual writers and authors working in a solo flow. They need a low-friction writing environment that stays out of the way while drafting, revising, and publishing content. Typical use happens in long, focused sessions where interruption cost is high.
+
+## Product Purpose
+Earnesty provides a focused writing workspace backed by Sanity content storage. It should make drafting, editing, and publishing feel calm and reliable, with minimal UI overhead. Success means users can stay in writing flow, trust autosave/publish states, and manage document metadata without cognitive load spikes.
+
+## Brand Personality
+Minimal, elegant, and easy. The interface should feel quiet and confident, with clear hierarchy and restrained visual choices that support concentration rather than decoration.
+
+## Anti-references
+- Dense, technical, cluttered interfaces with high control density.
+- Dashboard-like “ops console” aesthetics that prioritize tooling feel over writing flow.
+- Overly decorative or attention-seeking UI patterns that compete with content.
+
+## Design Principles
+1. Keep writing in flow: prioritize uninterrupted drafting and predictable editor behavior over feature prominence.
+2. Make system state legible: save, publish, and error states must be visible, plain-language, and unambiguous.
+3. Reduce interface noise: each visible control should earn its place and appear at the right moment.
+4. Preserve consistency across surfaces: menus, modals, and editor affordances should share one cohesive interaction vocabulary.
+5. Accessibility is baseline quality: readability, contrast, keyboard usability, and reduced-motion behavior are non-negotiable.
+
+## Accessibility & Inclusion
+Target WCAG 2.1 AA as the baseline for all redesign recommendations. Prioritize robust text contrast, clear focus states, keyboard-operable controls, and reduced-motion alternatives for animated transitions and indicators.


### PR DESCRIPTION
## Why
The design revision and critique workflow needed a canonical product context in-repo. Without this baseline, design recommendations and follow-up planning are less consistent and harder to review.

## What changed
This PR adds `PRODUCT.md` at the repository root with the agreed product strategy context for Earnesty:

- register (`product`)
- target users and product purpose
- brand/personality direction
- anti-references to avoid
- design principles
- accessibility baseline (WCAG 2.1 AA)

## Notes for reviewers
This is a documentation-only change intended to support design critique/planning work. No runtime or UI code paths were modified.