### PR TITLE
chore: rename frontend package and release component to earnesty

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "earnesty",
   "version": "2.0.0",
   "private": true,
   "type": "module",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     "app": {
       "release-type": "node",
+      "component": "earnesty",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false


### PR DESCRIPTION
The frontend package and release naming still used `frontend`, which no longer matches the product name. This aligns package metadata and release automation with `earnesty` so future releases are consistently named.

## What changed
- Renamed `app/package.json` package name from `frontend` to `earnesty`.
- Updated release-please config for `app` to set `component: "earnesty"`, which changes tag/release naming to `earnesty-v*` going forward.
- Backfilled historical release naming by replacing existing `frontend-v*` tags/releases with matching `earnesty-v*` tags/releases on the same commits.

## Notes for reviewers
- No application runtime behavior changed; this is metadata/release automation alignment.
- Historical release rewrite was performed intentionally so old and new releases follow the same naming convention.