### PR TITLE
fix: accessibility and UX consistency pass for focused writer

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "frontend",
+  "name": "earnesty",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
+      "name": "earnesty",
       "version": "2.0.0",
       "dependencies": {
         "@catppuccin/palette": "^1.8.0",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -118,7 +118,7 @@ async function onMetadataSubmit(meta: DocumentMeta) {
     await persistMetadata(meta)
     showMetadataModal.value = false
   } catch (err) {
-    metadataError.value = toMessage(err, 'Failed to save metadata')
+    metadataError.value = toMessage(err, 'Failed to save metadata. Please retry.')
     trackException(err instanceof Error ? err : new Error(String(err)), { action: 'save_metadata' })
   } finally {
     metadataSubmitting.value = false
@@ -141,7 +141,7 @@ async function onPublishConfirm(meta: DocumentMeta) {
     await persistMetadata(meta)
   } catch (err) {
     console.error('[publish] pre-publish save failed:', err)
-    publishError.value = toMessage(err, 'Failed to save metadata before publish')
+    publishError.value = toMessage(err, 'Failed to save metadata before publish. Fix the fields and retry.')
     publishSubmitting.value = false
     trackException(err instanceof Error ? err : new Error(String(err)), { action: 'pre_publish_save' })
     return

--- a/app/src/assets/__tests__/base.test.ts
+++ b/app/src/assets/__tests__/base.test.ts
@@ -5,12 +5,24 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 describe('base stylesheet', () => {
+  const testDir = dirname(fileURLToPath(import.meta.url))
+  const css = readFileSync(resolve(testDir, '../base.css'), 'utf8')
+
   it('does not reserve a stable scrollbar gutter on the root html element', () => {
-    const testDir = dirname(fileURLToPath(import.meta.url))
-    const css = readFileSync(resolve(testDir, '../base.css'), 'utf8')
     const htmlRule = css.match(/html\s*\{[^}]*\}/)?.[0]
 
     expect(htmlRule).toBeTruthy()
     expect(htmlRule).not.toMatch(/scrollbar-gutter\s*:\s*stable\b/)
+  })
+
+  it('defines a reduced-motion override for animations and transitions', () => {
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/)
+    expect(css).toMatch(/animation-duration:\s*0\.01ms\s*!important/)
+    expect(css).toMatch(/transition-duration:\s*0\.01ms\s*!important/)
+  })
+
+  it('sets native control color-scheme per active theme', () => {
+    expect(css).toMatch(/\[data-theme="light"]\s*\{[\s\S]*color-scheme:\s*light;/)
+    expect(css).toMatch(/\[data-theme="dark"]\s*\{[\s\S]*color-scheme:\s*dark;/)
   })
 })

--- a/app/src/assets/base.css
+++ b/app/src/assets/base.css
@@ -27,6 +27,7 @@
   --ctp-base:      #eff1f5;
   --ctp-mantle:    #e6e9ef;
   --ctp-crust:     #dce0e8;
+  color-scheme: light;
 }
 
 /* Catppuccin Macchiato (dark) */
@@ -57,6 +58,7 @@
   --ctp-base:      #24273a;
   --ctp-mantle:    #1e2030;
   --ctp-crust:     #181926;
+  color-scheme: dark;
 }
 
 /* Catppuccin-inspired Whimsical mode — vibrant accents, no base/text neutrals */
@@ -88,6 +90,13 @@
   --ctp-base:      #361428;
   --ctp-mantle:    #2a0e1f;
   --ctp-crust:     #1f0816;
+  color-scheme: dark;
+}
+
+:root {
+  --ui-label-color: var(--ctp-subtext1);
+  --ui-hint-color: var(--ctp-subtext1);
+  --ui-placeholder-color: var(--ctp-subtext1);
 }
 
 *,
@@ -141,4 +150,15 @@ a:hover {
   background: var(--ctp-surface0);
   border-color: var(--ctp-surface2);
   color: var(--ctp-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -439,8 +439,8 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   left: 0;
   right: 0;
   z-index: 100;
-  opacity: 0;
-  transition: opacity 0.35s ease;
+  opacity: 0.72;
+  transition: opacity 0.2s ease;
 }
 
 .menubar:hover,
@@ -492,7 +492,7 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
 
 .menubar__doc-title {
   font-size: var(--step--1);
-  color: var(--ctp-subtext0);
+  color: var(--ctp-subtext1);
   padding: 0 var(--space-xs);
   border-left: 1px solid var(--ctp-surface1);
   max-width: 260px;
@@ -609,7 +609,7 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   border-left: 1px solid var(--ctp-surface1);
 }
 
-.menubar__save--saving { color: var(--ctp-subtext0); }
+.menubar__save--saving { color: var(--ctp-subtext1); }
 .menubar__save--saved  { color: var(--ctp-green); }
 .menubar__save--error  { color: var(--ctp-red); }
 

--- a/app/src/components/BaseModal.vue
+++ b/app/src/components/BaseModal.vue
@@ -17,6 +17,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
     <div
       class="overlay"
       role="dialog"
+      aria-modal="true"
       :aria-label="props.title"
       @click.self="emit('close')"
     >

--- a/app/src/components/BlockSettingsPopover.vue
+++ b/app/src/components/BlockSettingsPopover.vue
@@ -178,7 +178,7 @@ onUnmounted(() => {
 }
 
 .bsp__optional {
-  color: var(--ctp-overlay0);
+  color: var(--ui-hint-color);
   font-weight: 400;
   text-transform: none;
   letter-spacing: 0;
@@ -223,7 +223,7 @@ onUnmounted(() => {
 }
 
 .bsp__input::placeholder {
-  color: var(--ctp-overlay0);
+  color: var(--ui-placeholder-color);
 }
 
 .bsp__apply {

--- a/app/src/components/DocumentInfoModal.vue
+++ b/app/src/components/DocumentInfoModal.vue
@@ -170,7 +170,7 @@ function save() {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--ctp-subtext0);
+  color: var(--ui-label-color);
 }
 
 .field__input {
@@ -183,11 +183,14 @@ function save() {
   outline: none;
   transition: border-color 0.15s ease;
   width: 100%;
-  color-scheme: dark;
 }
 
 .field__input:focus {
   border-color: var(--ctp-mauve);
+}
+
+.field__input::placeholder {
+  color: var(--ui-placeholder-color);
 }
 
 .field__input--mono {
@@ -198,7 +201,7 @@ function save() {
 
 .field__hint {
   font-size: 0.72rem;
-  color: var(--ctp-overlay1);
+  color: var(--ui-hint-color);
 }
 
 /* ── Tag input ────────────────────────────────────────────────────────────── */
@@ -233,7 +236,7 @@ function save() {
 .tag__remove {
   background: none;
   border: none;
-  color: var(--ctp-overlay1);
+  color: var(--ui-hint-color);
   font-size: 0.65rem;
   cursor: pointer;
   padding: 0;
@@ -253,6 +256,10 @@ function save() {
   outline: none;
   color: var(--ctp-text);
   font-size: 0.9rem;
+}
+
+.tag-input__field::placeholder {
+  color: var(--ui-placeholder-color);
 }
 
 /* ── Actions ─────────────────────────────────────────────────────────────── */

--- a/app/src/components/NewDocumentModal.vue
+++ b/app/src/components/NewDocumentModal.vue
@@ -108,7 +108,7 @@ function escapeHtml(str: string): string {
 
       <div class="actions">
         <button
-          class="btn btn--secondary"
+          class="btn btn--ghost"
           :disabled="creating"
           @click="$emit('close')"
         >
@@ -141,18 +141,18 @@ function escapeHtml(str: string): string {
 }
 
 .field__label {
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  color: var(--ctp-subtext1);
+  color: var(--ui-label-color);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
 }
 
 .field__hint {
   font-weight: 400;
   text-transform: none;
   letter-spacing: 0;
-  color: var(--ctp-subtext0);
+  color: var(--ui-hint-color);
 }
 
 .field__input {
@@ -168,7 +168,7 @@ function escapeHtml(str: string): string {
   box-sizing: border-box;
 }
 
-.field__input::placeholder { color: var(--ctp-subtext0); }
+.field__input::placeholder { color: var(--ui-placeholder-color); }
 .field__input:focus { border-color: var(--ctp-mauve); }
 .field__input:disabled { opacity: 0.5; }
 
@@ -199,13 +199,13 @@ function escapeHtml(str: string): string {
 }
 
 .btn {
-  border: none;
+  border: 1px solid transparent;
   border-radius: 6px;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
   font-weight: 500;
-  padding: 0.5rem 1rem;
+  padding: 0.4rem 0.9rem;
   cursor: pointer;
-  transition: opacity 0.15s ease, background 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
 .btn:disabled {
@@ -213,13 +213,14 @@ function escapeHtml(str: string): string {
   cursor: not-allowed;
 }
 
-.btn--secondary {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+.btn--ghost {
+  background: transparent;
+  border-color: var(--ctp-surface1);
+  color: var(--ctp-subtext1);
 }
 
-.btn--secondary:not(:disabled):hover {
-  background: var(--ctp-surface1);
+.btn--ghost:hover {
+  background: var(--ctp-surface0);
 }
 
 .btn--primary {
@@ -228,6 +229,6 @@ function escapeHtml(str: string): string {
 }
 
 .btn--primary:not(:disabled):hover {
-  opacity: 0.85;
+  filter: brightness(1.1);
 }
 </style>

--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -285,7 +285,7 @@ function signIn() {
   box-sizing: border-box;
 }
 
-.search::placeholder { color: var(--ctp-subtext0); }
+.search::placeholder { color: var(--ui-placeholder-color); }
 .search:focus { border-color: var(--ctp-mauve); }
 
 .sort-tabs {
@@ -322,7 +322,7 @@ function signIn() {
 
 /* ── Status messages ───────────────────────────────────────────────────────── */
 .status {
-  color: var(--ctp-subtext0);
+  color: var(--ui-hint-color);
   font-size: 0.875rem;
   text-align: center;
   padding: 2rem 0;
@@ -335,7 +335,7 @@ function signIn() {
   flex-direction: column;
   align-items: center;
   gap: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--ui-hint-color);
 }
 
 .signin-btn {
@@ -401,7 +401,7 @@ function signIn() {
 }
 
 .doc-list__date {
-  color: var(--ctp-subtext0);
+  color: var(--ctp-subtext1);
   font-size: 0.75rem;
   flex-shrink: 0;
 }
@@ -418,8 +418,20 @@ function signIn() {
 }
 
 /* ── Preview animation ─────────────────────────────────────────────────────── */
-.preview-fade-enter-active { transition: opacity 0.15s ease, max-height 0.2s ease; }
-.preview-fade-leave-active { transition: opacity 0.1s ease, max-height 0.15s ease; }
-.preview-fade-enter-from, .preview-fade-leave-to { opacity: 0; max-height: 0; }
-.preview-fade-enter-to, .preview-fade-leave-from { opacity: 1; max-height: 5rem; }
+.preview-fade-enter-active,
+.preview-fade-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.preview-fade-enter-from,
+.preview-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-2px);
+}
+
+.preview-fade-enter-to,
+.preview-fade-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
 </style>

--- a/app/src/components/PublishModal.vue
+++ b/app/src/components/PublishModal.vue
@@ -261,7 +261,7 @@ function submit() {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--ctp-subtext0);
+  color: var(--ui-label-color);
 }
 
 .field__input {
@@ -275,7 +275,6 @@ function submit() {
   transition: border-color 0.15s ease;
   width: 100%;
   box-sizing: border-box;
-  color-scheme: dark;
 }
 
 .field__input-row .field__input {
@@ -284,6 +283,10 @@ function submit() {
 
 .field__input:focus {
   border-color: var(--ctp-mauve);
+}
+
+.field__input::placeholder {
+  color: var(--ui-placeholder-color);
 }
 
 .field__input--mono {
@@ -310,6 +313,10 @@ function submit() {
   margin: 0;
   font-size: 0.82rem;
   color: var(--ctp-red);
+  background: color-mix(in srgb, var(--ctp-red) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ctp-red) 25%, transparent);
+  border-radius: 6px;
+  padding: 0.5rem 0.65rem;
 }
 
 .btn {

--- a/app/src/components/SettingsModal.vue
+++ b/app/src/components/SettingsModal.vue
@@ -131,7 +131,7 @@ const widthLabels: Record<number, string> = {
   width: 5.5rem;
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--ui-label-color);
   text-align: left;
 }
 

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -572,7 +572,7 @@ watch(
 
 .editor__content :deep(.ProseMirror h1[data-type='title'] + p[data-start-placeholder]:is(:empty, :has(> br.ProseMirror-trailingBreak:only-child))::before) {
   content: attr(data-start-placeholder);
-  color: var(--ctp-subtext0);
+  color: var(--ui-placeholder-color);
   pointer-events: none;
 }
 
@@ -597,7 +597,7 @@ watch(
 
 .editor__content :deep(.ProseMirror h1[data-type='title']:empty::before) {
   content: 'Untitled';
-  color: var(--ctp-overlay0);
+  color: var(--ui-placeholder-color);
   pointer-events: none;
 }
 
@@ -619,9 +619,11 @@ watch(
 
 /* ── Blockquote ───────────────────────────────────────────────────────────── */
 .editor__content :deep(.ProseMirror blockquote) {
-  border-left: 3px solid var(--ctp-mauve);
+  border: 1px solid var(--ctp-surface1);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--ctp-surface0) 35%, transparent);
   margin: 1.2em 0;
-  padding: 0.15em 1em;
+  padding: 0.55em 0.9em;
   color: var(--ctp-subtext1);
   font-style: italic;
 }

--- a/app/src/views/__tests__/HomeView.styles.test.ts
+++ b/app/src/views/__tests__/HomeView.styles.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+describe('HomeView styles', () => {
+  const testDir = dirname(fileURLToPath(import.meta.url))
+  const source = readFileSync(resolve(testDir, '../HomeView.vue'), 'utf8')
+
+  it('does not use a one-sided accent stripe on blockquotes', () => {
+    expect(source).not.toMatch(/\.editor__content\s*:deep\(\.ProseMirror blockquote\)\s*\{[\s\S]*border-left:/)
+  })
+})


### PR DESCRIPTION
## Why
Issue #183 identified key UX and accessibility gaps in the focused writing experience: no reduced-motion path, a blockquote side-stripe anti-pattern, low-contrast helper/placeholder text, hover-dependent menubar discoverability, and inconsistent modal/form treatment.

## What changed
- Added a global reduced-motion override and theme-aware native control rendering in `app/src/assets/base.css`.
- Reworked editor blockquote styling in `HomeView.vue` to remove the one-sided accent stripe and use a subtler quote treatment.
- Made the menubar visible by default at low prominence in `AppMenuBar.vue` so core actions are discoverable without hover.
- Rebalanced helper/placeholder/secondary text contrast and standardized modal/form visual vocabulary across:
  - `NewDocumentModal.vue`
  - `DocumentInfoModal.vue`
  - `PublishModal.vue`
  - `OpenDocumentModal.vue`
  - `SettingsModal.vue`
  - `BaseModal.vue`
  - `BlockSettingsPopover.vue`
- Improved metadata/publish error copy in `App.vue` to provide clearer recovery guidance.
- Added regression checks for CSS guarantees:
  - `app/src/assets/__tests__/base.test.ts`
  - `app/src/views/__tests__/HomeView.styles.test.ts`

## Notes for reviewers
- `app/package-lock.json` is included from dependency installation in this session; no package manifest changes were introduced.

Fixes: #183