### PR TITLE
fix: Restore left-marker styling for blockquotes

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -671,11 +671,9 @@ watch(
 
 /* ── Blockquote ───────────────────────────────────────────────────────────── */
 .editor__content :deep(.ProseMirror blockquote) {
-  border: 1px solid var(--ctp-surface1);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--ctp-surface0) 35%, transparent);
   margin: 1.2em 0;
-  padding: 0.55em 0.9em;
+  padding: 0.1em 0 0.1em 0.95em;
+  border-left: 2px solid var(--ctp-surface2);
   color: var(--ctp-subtext1);
   font-style: italic;
 }

--- a/app/src/views/__tests__/HomeView.styles.test.ts
+++ b/app/src/views/__tests__/HomeView.styles.test.ts
@@ -8,7 +8,8 @@ describe('HomeView styles', () => {
   const testDir = dirname(fileURLToPath(import.meta.url))
   const source = readFileSync(resolve(testDir, '../HomeView.vue'), 'utf8')
 
-  it('does not use a one-sided accent stripe on blockquotes', () => {
-    expect(source).not.toMatch(/\.editor__content\s*:deep\(\.ProseMirror blockquote\)\s*\{[\s\S]*border-left:/)
+  it('uses a one-sided accent stripe on blockquotes instead of a full border', () => {
+    expect(source).toMatch(/\.editor__content\s*:deep\(\.ProseMirror blockquote\)\s*\{[^}]*border-left:/)
+    expect(source).not.toMatch(/\.editor__content\s*:deep\(\.ProseMirror blockquote\)\s*\{[^}]*\bborder\s*:/)
   })
 })


### PR DESCRIPTION
Blockquotes were styled as bordered containers, which made them look too similar to code blocks and reduced visual clarity while writing. This change restores a quote-specific look with a one-sided marker.

## What changed
- Replaced the full blockquote border/background treatment with a left marker style in the editor content CSS.
- Adjusted blockquote padding to fit the marker-based presentation.
- Updated the style regression test to assert that blockquotes use `border-left` and do not use a full `border` declaration.

## Notes for reviewers
This is a focused visual rollback for blockquotes only. No behavior or content model changes were made.