### PR TITLE
fix: display Entra ID instead of Aad in account modal

### DIFF
--- a/app/src/components/UserModal.vue
+++ b/app/src/components/UserModal.vue
@@ -6,8 +6,12 @@ defineProps<{ user: AuthUser }>()
 
 const emit = defineEmits<{ close: []; logout: [] }>()
 
+const PROVIDER_LABELS: Record<string, string> = {
+  aad: 'Entra ID',
+}
+
 function providerLabel(identityProvider: string): string {
-  return identityProvider.charAt(0).toUpperCase() + identityProvider.slice(1)
+  return PROVIDER_LABELS[identityProvider] ?? (identityProvider.charAt(0).toUpperCase() + identityProvider.slice(1))
 }
 </script>
 


### PR DESCRIPTION
## Summary

The account modal was displaying "Signed in via Aad" because the `providerLabel` function simply capitalised the raw identity provider string `aad`.

## Changes

- Added a `PROVIDER_LABELS` lookup map in `UserModal.vue` that maps known provider IDs to their display names (`aad` → `Entra ID`)
- The fallback behaviour (capitalise first letter) is preserved for any other providers