### PR TITLE
feat: make theme and font runtime-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Both frontend and API use typed runtime configuration so you can customize schem
 | `VITE_SANITY_DATASET` | No | `production` |
 | `VITE_SANITY_API_VERSION` | No | `2024-01-01` |
 | `VITE_SANITY_SCHEMA_CONFIG` | No | JSON schema config. If unset, the frontend uses a built-in single-type default equivalent to `blog` / `title` / `body` / `slug` / `publishedAt`. |
+| `VITE_THEME_CONFIG` | No | JSON theme config for `light` and `dark` themes. If unset, the frontend uses built-in Catppuccin Latte (light) and Macchiato (dark). |
+| `VITE_FONT_CONFIG` | No | JSON font-family config. If set, it must provide `sansSerif`, `serif`, and `comical`. |
 | `VITE_SANITY_DRAFT_PREFIX` | No | `drafts.` (must end with `.`) |
 | `VITE_AUTH_PROVIDER` | No | `swa` (`swa` or `api`) |
 | `VITE_AUTH_CURRENT_USER_PATH` | No | `/.auth/me` for `swa`, `/api/me` for `api` |
@@ -136,6 +138,41 @@ Validation is fail-fast: invalid or missing required settings throw explicit run
       "publishedAtField": "updatedAt"
     }
   ]
+}
+```
+
+#### Theme config example
+
+`VITE_THEME_CONFIG` uses this JSON shape (both themes are required when set):
+
+```json
+{
+  "light": {
+    "colorScheme": "light",
+    "colors": {
+      "--ctp-base": "#eff1f5",
+      "--ctp-text": "#4c4f69"
+    }
+  },
+  "dark": {
+    "colorScheme": "dark",
+    "colors": {
+      "--ctp-base": "#24273a",
+      "--ctp-text": "#cad3f5"
+    }
+  }
+}
+```
+
+#### Font config example
+
+`VITE_FONT_CONFIG` uses this JSON shape (all keys are required when set):
+
+```json
+{
+  "sansSerif": "system-ui, -apple-system, sans-serif",
+  "serif": "'Lora', Georgia, serif",
+  "comical": "'Comic Sans MS', cursive"
 }
 ```
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -4,6 +4,10 @@ VITE_SANITY_DATASET=dev
 # Optional Sanity schema config JSON. If unset, the built-in default schema is:
 # {"defaultType":"blog","types":[{"name":"blog","titleField":"title","bodyField":"body","slugField":"slug","publishedAtField":"publishedAt"}]}
 # VITE_SANITY_SCHEMA_CONFIG={"defaultType":"blog","types":[{"name":"blog","label":"Blog","titleField":"title","bodyField":"body","slugField":"slug","publishedAtField":"publishedAt","metadataFields":[{"key":"title","label":"Title","field":"title","type":"string","required":true},{"key":"slug","label":"Slug","field":"slug","type":"slug","required":true},{"key":"publishedAt","label":"Published at","field":"publishedAt","type":"datetime"},{"key":"tags","label":"Tags","field":"tags","type":"stringArray"}]}]}
+# Optional UI theme config JSON. If unset, the built-in Catppuccin light/dark themes are used.
+# VITE_THEME_CONFIG={"light":{"colorScheme":"light","colors":{"--ctp-base":"#eff1f5","--ctp-text":"#4c4f69"}},"dark":{"colorScheme":"dark","colors":{"--ctp-base":"#24273a","--ctp-text":"#cad3f5"}}}
+# Optional font-family config JSON. If set, all three keys are required.
+# VITE_FONT_CONFIG={"sansSerif":"system-ui, -apple-system, sans-serif","serif":"'Lora', Georgia, serif","comical":"'Comic Sans MS', cursive"}
 VITE_SANITY_DRAFT_PREFIX=drafts.
 # Optional auth provider/runtime contract
 VITE_AUTH_PROVIDER=swa

--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -10,6 +10,8 @@ interface ImportMetaEnv {
   readonly VITE_SANITY_DATASET?: string
   readonly VITE_SANITY_API_VERSION?: string
   readonly VITE_SANITY_SCHEMA_CONFIG?: string
+  readonly VITE_THEME_CONFIG?: string
+  readonly VITE_FONT_CONFIG?: string
   readonly VITE_SANITY_DRAFT_PREFIX?: string
   readonly VITE_AUTH_PROVIDER?: string
   readonly VITE_AUTH_CURRENT_USER_PATH?: string

--- a/app/public/theme-init.js
+++ b/app/public/theme-init.js
@@ -1,8 +1,46 @@
 ;(function () {
+  function resolveTheme(theme) {
+    if (theme === 'light' || theme === 'dark') return theme
+    try {
+      if (globalThis.matchMedia && globalThis.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark'
+      }
+    } catch {
+      return 'light'
+    }
+    return 'light'
+  }
+
+  function readSettings() {
+    var storage = globalThis.localStorage
+    if (!storage) return {}
+
+    var knownKeys = ['earnesty:settings', 'ernesty:settings']
+    for (var i = 0; i < storage.length; i++) {
+      var key = storage.key(i)
+      if (typeof key === 'string' && /:settings$/.test(key) && knownKeys.indexOf(key) === -1) {
+        knownKeys.unshift(key)
+      }
+    }
+
+    for (var j = 0; j < knownKeys.length; j++) {
+      var raw = storage.getItem(knownKeys[j])
+      if (!raw) continue
+      try {
+        var parsed = JSON.parse(raw)
+        if (parsed && typeof parsed === 'object') return parsed
+      } catch {
+        continue
+      }
+    }
+
+    return {}
+  }
+
   try {
-    var settings = JSON.parse(globalThis.localStorage?.getItem('ernesty:settings') || '{}')
-    globalThis.document?.documentElement?.setAttribute('data-theme', settings.theme || 'dark')
+    var settings = readSettings()
+    globalThis.document?.documentElement?.setAttribute('data-theme', resolveTheme(settings.theme))
   } catch {
-    globalThis.document?.documentElement?.setAttribute('data-theme', 'dark')
+    globalThis.document?.documentElement?.setAttribute('data-theme', 'light')
   }
 })()

--- a/app/src/assets/base.css
+++ b/app/src/assets/base.css
@@ -61,38 +61,6 @@
   color-scheme: dark;
 }
 
-/* Catppuccin-inspired Whimsical mode — vibrant accents, no base/text neutrals */
-[data-theme="whimsical"] {
-  --ctp-rosewater: #f4dbd6;
-  --ctp-flamingo:  #f0c6c6;
-  --ctp-pink:      #f5bde6;
-  --ctp-mauve:     #c6a0f6;
-  --ctp-red:       #ed8796;
-  --ctp-maroon:    #ee99a0;
-  --ctp-peach:     #f5a97f;
-  --ctp-yellow:    #eed49f;
-  --ctp-green:     #a6da95;
-  --ctp-teal:      #8bd5ca;
-  --ctp-sky:       #91d7e3;
-  --ctp-sapphire:  #7dc4e4;
-  --ctp-blue:      #8aadf4;
-  --ctp-lavender:  #b7bdf8;
-  /* Vibrant replacements: avoid base/text neutrals */
-  --ctp-text:      #f5bde6;
-  --ctp-subtext1:  #f0c6c6;
-  --ctp-subtext0:  #eed49f;
-  --ctp-overlay2:  #c6a0f6;
-  --ctp-overlay1:  #b7bdf8;
-  --ctp-overlay0:  #8aadf4;
-  --ctp-surface2:  #494d64;
-  --ctp-surface1:  #363a4f;
-  --ctp-surface0:  #4a1f3a;
-  --ctp-base:      #361428;
-  --ctp-mantle:    #2a0e1f;
-  --ctp-crust:     #1f0816;
-  color-scheme: dark;
-}
-
 :root {
   --ui-label-color: var(--ctp-subtext1);
   --ui-hint-color: var(--ctp-subtext1);

--- a/app/src/components/SettingsModal.vue
+++ b/app/src/components/SettingsModal.vue
@@ -22,15 +22,15 @@ const auth = useAuthStore()
 const grammarCapability = ref<GrammarCapabilityResult | null>(null)
 
 const themes: { value: Theme; label: string }[] = [
+  { value: 'system', label: 'System' },
   { value: 'light', label: 'Light' },
   { value: 'dark', label: 'Dark' },
-  { value: 'whimsical', label: 'Whimsical' },
 ]
 
 const fonts: { value: Font; label: string }[] = [
   { value: 'serif', label: 'Serif' },
   { value: 'sans-serif', label: 'Sans-serif' },
-  { value: 'comic-sans', label: 'Comic Sans' },
+  { value: 'comical', label: 'Comical' },
 ]
 
 const fontSizeLabels: Record<number, string> = {

--- a/app/src/config/__tests__/runtime.test.ts
+++ b/app/src/config/__tests__/runtime.test.ts
@@ -24,6 +24,11 @@ describe('createRuntimeConfig', () => {
     expect(config.auth.loginPath).toBe('/.auth/login/aad')
     expect(config.app.name).toBe('Earnesty')
     expect(config.app.storageNamespace).toBe('earnesty')
+    expect(config.appearance.themes.light.colorScheme).toBe('light')
+    expect(config.appearance.themes.dark.colorScheme).toBe('dark')
+    expect(config.appearance.fonts.sansSerif).toContain('system-ui')
+    expect(config.appearance.fonts.serif).toContain('Lora')
+    expect(config.appearance.fonts.comical).toContain('Comic Sans')
   })
 
   it('throws when VITE_SANITY_PROJECT_ID is missing outside test mode', () => {
@@ -110,5 +115,60 @@ describe('createRuntimeConfig', () => {
     expect(() => createRuntimeConfig(makeEnv({ VITE_APP_STORAGE_NAMESPACE: 'My NS!' }))).toThrow(
       'VITE_APP_STORAGE_NAMESPACE',
     )
+  })
+
+  it('uses custom theme and font config when provided', () => {
+    const config = createRuntimeConfig(makeEnv({
+      VITE_THEME_CONFIG: JSON.stringify({
+        light: {
+          colorScheme: 'light',
+          colors: {
+            '--ctp-base': '#ffffff',
+            '--ctp-text': '#101010',
+          },
+        },
+        dark: {
+          colorScheme: 'dark',
+          colors: {
+            '--ctp-base': '#101010',
+            '--ctp-text': '#ffffff',
+          },
+        },
+      }),
+      VITE_FONT_CONFIG: JSON.stringify({
+        sansSerif: 'Inter, system-ui, sans-serif',
+        serif: 'Merriweather, serif',
+        comical: '"Comic Neue", cursive',
+      }),
+    }))
+
+    expect(config.appearance.themes.light.colors['--ctp-base']).toBe('#ffffff')
+    expect(config.appearance.themes.dark.colors['--ctp-text']).toBe('#ffffff')
+    expect(config.appearance.fonts).toEqual({
+      sansSerif: 'Inter, system-ui, sans-serif',
+      serif: 'Merriweather, serif',
+      comical: '"Comic Neue", cursive',
+    })
+  })
+
+  it('throws when custom theme config is missing required themes', () => {
+    expect(() => createRuntimeConfig(makeEnv({
+      VITE_THEME_CONFIG: JSON.stringify({
+        light: {
+          colors: {
+            '--ctp-base': '#ffffff',
+          },
+        },
+      }),
+    }))).toThrow('VITE_THEME_CONFIG.dark')
+  })
+
+  it('throws when custom font config omits a required font family', () => {
+    expect(() => createRuntimeConfig(makeEnv({
+      VITE_FONT_CONFIG: JSON.stringify({
+        sansSerif: 'Inter, sans-serif',
+        serif: 'Merriweather, serif',
+      }),
+    }))).toThrow('VITE_FONT_CONFIG.comical')
   })
 })

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -34,6 +34,10 @@ export interface FrontendRuntimeConfig {
   telemetry: {
     applicationInsightsConnectionString?: string
   }
+  appearance: {
+    themes: Record<ResolvedTheme, ThemeRuntimeConfig>
+    fonts: FontRuntimeConfig
+  }
 }
 
 export type MetadataFieldType = 'string' | 'slug' | 'datetime' | 'stringArray' | 'boolean'
@@ -56,6 +60,19 @@ export interface ContentTypeConfig {
   metadataFields: MetadataFieldConfig[]
 }
 
+export type ResolvedTheme = 'light' | 'dark'
+
+export interface ThemeRuntimeConfig {
+  colorScheme: 'light' | 'dark'
+  colors: Record<string, string>
+}
+
+export interface FontRuntimeConfig {
+  sansSerif: string
+  serif: string
+  comical: string
+}
+
 const DEFAULT_CONTENT_FIELDS = {
   documentType: 'blog',
   titleField: 'title',
@@ -63,6 +80,77 @@ const DEFAULT_CONTENT_FIELDS = {
   slugField: 'slug',
   publishedAtField: 'publishedAt',
 } as const
+
+const DEFAULT_THEME_CONFIG: Record<ResolvedTheme, ThemeRuntimeConfig> = {
+  light: {
+    colorScheme: 'light',
+    colors: {
+      '--ctp-rosewater': '#dc8a78',
+      '--ctp-flamingo': '#dd7878',
+      '--ctp-pink': '#ea76cb',
+      '--ctp-mauve': '#8839ef',
+      '--ctp-red': '#d20f39',
+      '--ctp-maroon': '#e64553',
+      '--ctp-peach': '#fe640b',
+      '--ctp-yellow': '#df8e1d',
+      '--ctp-green': '#40a02b',
+      '--ctp-teal': '#179299',
+      '--ctp-sky': '#04a5e5',
+      '--ctp-sapphire': '#209fb5',
+      '--ctp-blue': '#1e66f5',
+      '--ctp-lavender': '#7287fd',
+      '--ctp-text': '#4c4f69',
+      '--ctp-subtext1': '#5c5f77',
+      '--ctp-subtext0': '#6c6f85',
+      '--ctp-overlay2': '#7c7f93',
+      '--ctp-overlay1': '#8c8fa1',
+      '--ctp-overlay0': '#9ca0b0',
+      '--ctp-surface2': '#acb0be',
+      '--ctp-surface1': '#bcc0cc',
+      '--ctp-surface0': '#ccd0da',
+      '--ctp-base': '#eff1f5',
+      '--ctp-mantle': '#e6e9ef',
+      '--ctp-crust': '#dce0e8',
+    },
+  },
+  dark: {
+    colorScheme: 'dark',
+    colors: {
+      '--ctp-rosewater': '#f4dbd6',
+      '--ctp-flamingo': '#f0c6c6',
+      '--ctp-pink': '#f5bde6',
+      '--ctp-mauve': '#c6a0f6',
+      '--ctp-red': '#ed8796',
+      '--ctp-maroon': '#ee99a0',
+      '--ctp-peach': '#f5a97f',
+      '--ctp-yellow': '#eed49f',
+      '--ctp-green': '#a6da95',
+      '--ctp-teal': '#8bd5ca',
+      '--ctp-sky': '#91d7e3',
+      '--ctp-sapphire': '#7dc4e4',
+      '--ctp-blue': '#8aadf4',
+      '--ctp-lavender': '#b7bdf8',
+      '--ctp-text': '#cad3f5',
+      '--ctp-subtext1': '#b8c0e0',
+      '--ctp-subtext0': '#a5adcb',
+      '--ctp-overlay2': '#939ab7',
+      '--ctp-overlay1': '#8087a2',
+      '--ctp-overlay0': '#6e738d',
+      '--ctp-surface2': '#5b6078',
+      '--ctp-surface1': '#494d64',
+      '--ctp-surface0': '#363a4f',
+      '--ctp-base': '#24273a',
+      '--ctp-mantle': '#1e2030',
+      '--ctp-crust': '#181926',
+    },
+  },
+}
+
+const DEFAULT_FONT_CONFIG: FontRuntimeConfig = {
+  sansSerif: 'system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+  serif: '\'Lora\', Georgia, \'Times New Roman\', serif',
+  comical: '\'Comic Sans MS\', \'Comic Sans\', cursive',
+}
 
 function envString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined
@@ -130,6 +218,22 @@ interface SchemaTypeInput {
 interface SchemaConfigInput {
   defaultType?: unknown
   types?: unknown
+}
+
+interface ThemeConfigInput {
+  light?: unknown
+  dark?: unknown
+}
+
+interface ThemeInput {
+  colorScheme?: unknown
+  colors?: unknown
+}
+
+interface FontConfigInput {
+  sansSerif?: unknown
+  serif?: unknown
+  comical?: unknown
 }
 
 function defaultMetadataFields(type: {
@@ -332,6 +436,90 @@ function readStorageNamespace(value: string | undefined, fallback: string): stri
   return ns
 }
 
+function readThemeName(value: unknown, key: string): ResolvedTheme {
+  if (value === 'light' || value === 'dark') return value
+  throw new Error(`Invalid runtime configuration: ${key} must be "light" or "dark"`)
+}
+
+function readThemeColors(value: unknown, key: string): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid runtime configuration: ${key} must be an object`)
+  }
+  const entries = Object.entries(value)
+  if (entries.length === 0) {
+    throw new Error(`Invalid runtime configuration: ${key} must not be empty`)
+  }
+  const colors: Record<string, string> = {}
+  for (const [name, raw] of entries) {
+    const cssVar = typeof name === 'string' ? name.trim() : ''
+    if (!cssVar.startsWith('--')) {
+      throw new Error(`Invalid runtime configuration: ${key}.${name} must be a CSS variable key`)
+    }
+    const color = typeof raw === 'string' ? raw.trim() : ''
+    if (!color) {
+      throw new Error(`Invalid runtime configuration: ${key}.${name} must be a non-empty string`)
+    }
+    colors[cssVar] = color
+  }
+  return colors
+}
+
+function readTheme(themeName: ResolvedTheme, value: unknown, key: string): ThemeRuntimeConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid runtime configuration: ${key} must be an object`)
+  }
+  const input = value as ThemeInput
+  return {
+    colorScheme: readThemeName(input.colorScheme ?? themeName, `${key}.colorScheme`),
+    colors: readThemeColors(input.colors, `${key}.colors`),
+  }
+}
+
+function readThemeConfig(value: string | undefined): Record<ResolvedTheme, ThemeRuntimeConfig> {
+  if (!value) return DEFAULT_THEME_CONFIG
+
+  let parsed: ThemeConfigInput
+  try {
+    parsed = JSON.parse(value) as ThemeConfigInput
+  } catch (error) {
+    throw new Error('Invalid runtime configuration: VITE_THEME_CONFIG must be valid JSON', {
+      cause: error,
+    })
+  }
+
+  return {
+    light: readTheme('light', parsed.light, 'VITE_THEME_CONFIG.light'),
+    dark: readTheme('dark', parsed.dark, 'VITE_THEME_CONFIG.dark'),
+  }
+}
+
+function readRequiredFontFamily(value: unknown, key: string): string {
+  const family = typeof value === 'string' ? value.trim() : ''
+  if (!family) {
+    throw new Error(`Invalid runtime configuration: ${key} must be a non-empty string`)
+  }
+  return family
+}
+
+function readFontConfig(value: string | undefined): FontRuntimeConfig {
+  if (!value) return DEFAULT_FONT_CONFIG
+
+  let parsed: FontConfigInput
+  try {
+    parsed = JSON.parse(value) as FontConfigInput
+  } catch (error) {
+    throw new Error('Invalid runtime configuration: VITE_FONT_CONFIG must be valid JSON', {
+      cause: error,
+    })
+  }
+
+  return {
+    sansSerif: readRequiredFontFamily(parsed.sansSerif, 'VITE_FONT_CONFIG.sansSerif'),
+    serif: readRequiredFontFamily(parsed.serif, 'VITE_FONT_CONFIG.serif'),
+    comical: readRequiredFontFamily(parsed.comical, 'VITE_FONT_CONFIG.comical'),
+  }
+}
+
 
 export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
   const appName = envString(env.VITE_APP_NAME) ?? 'Earnesty'
@@ -358,6 +546,8 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
   const authProvider = readAuthProvider(envString(env.VITE_AUTH_PROVIDER))
   const defaultCurrentUserPath = authProvider === 'api' ? '/api/me' : '/.auth/me'
   const schemaConfig = readSchemaConfig(envString(env.VITE_SANITY_SCHEMA_CONFIG))
+  const themeConfig = readThemeConfig(envString(env.VITE_THEME_CONFIG))
+  const fontConfig = readFontConfig(envString(env.VITE_FONT_CONFIG))
   const defaultTypeConfig = schemaConfig.types[schemaConfig.defaultType]
   if (!defaultTypeConfig) {
     throw new Error(`Invalid runtime configuration: unknown default type ${schemaConfig.defaultType}`)
@@ -402,6 +592,10 @@ export function createRuntimeConfig(env: ImportMetaEnv): FrontendRuntimeConfig {
     },
     telemetry: {
       applicationInsightsConnectionString: envString(env.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING),
+    },
+    appearance: {
+      themes: themeConfig,
+      fonts: fontConfig,
     },
   }
 }

--- a/app/src/stores/__tests__/settings.test.ts
+++ b/app/src/stores/__tests__/settings.test.ts
@@ -26,30 +26,44 @@ describe('settings store proofreading controls', () => {
     setActivePinia(createPinia())
     storage.clear()
     vi.stubGlobal('localStorage', storage)
+    vi.stubGlobal('matchMedia', vi.fn(() => ({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })))
     document.documentElement.removeAttribute('data-theme')
   })
 
   it('uses native proofreading defaults', () => {
     const store = useSettingsStore()
 
+    expect(store.settings.theme).toBe('system')
+    expect(store.settings.font).toBe('serif')
     expect(store.settings.proofreadingMode).toBe('native')
     expect(store.settings.spellcheck).toBe(true)
     expect(store.settings.autocorrect).toBe('on')
     expect(store.settings.writingSuggestions).toBe(true)
     expect(store.settings.editorLanguage).toBe('en')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
   })
 
   it('normalizes missing proofreading fields from stored settings', () => {
     storage.setItem(SETTINGS_KEY, JSON.stringify({
-      theme: 'light',
+      theme: 'whimsical',
       fontSize: 30,
       lineSpacing: 1.4,
-      font: 'serif',
+      font: 'comic-sans',
       contentWidth: 70,
     }))
 
     const store = useSettingsStore()
-    expect(store.settings.theme).toBe('light')
+    expect(store.settings.theme).toBe('system')
+    expect(store.settings.font).toBe('serif')
     expect(store.settings.proofreadingMode).toBe('native')
     expect(store.settings.editorLanguage).toBe('en')
   })

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
-import { runtimeConfig } from '../config/runtime'
+import { runtimeConfig, type ResolvedTheme } from '../config/runtime'
 
-export type Theme = 'light' | 'dark' | 'whimsical'
-export type Font = 'serif' | 'sans-serif' | 'comic-sans'
+export type Theme = 'system' | 'light' | 'dark'
+export type Font = 'serif' | 'sans-serif' | 'comical'
 export type ProofreadingMode = 'off' | 'native' | 'advanced'
 export type AutocorrectSetting = 'on' | 'off'
 
@@ -12,82 +12,19 @@ export const CONTENT_WIDTHS = [50, 60, 70] as const
 
 export function fontFamilyFor(font: Font): string {
   switch (font) {
-    case 'sans-serif': return 'system-ui, -apple-system, BlinkMacSystemFont, sans-serif'
-    case 'comic-sans': return '\'Comic Sans MS\', \'Comic Sans\', cursive'
-    default:           return '\'Lora\', Georgia, \'Times New Roman\', serif'
-  }
-}
-
-/* ── Whimsical colour palettes ─────────────────────────────────────────── */
-const WHIMSICAL_PALETTES = [
-  {
-    name: 'pink',
-    vars: {
-      '--ctp-text': '#f5bde6', '--ctp-subtext1': '#f0c6c6', '--ctp-subtext0': '#eed49f',
-      '--ctp-overlay2': '#c6a0f6', '--ctp-overlay1': '#b7bdf8', '--ctp-overlay0': '#8aadf4',
-      '--ctp-surface2': '#494d64', '--ctp-surface1': '#363a4f', '--ctp-surface0': '#4a1f3a',
-      '--ctp-base': '#361428', '--ctp-mantle': '#2a0e1f', '--ctp-crust': '#1f0816',
-    },
-  },
-  {
-    name: 'lavender',
-    vars: {
-      '--ctp-text': '#c6b4f8', '--ctp-subtext1': '#b7a5e8', '--ctp-subtext0': '#dab8f0',
-      '--ctp-overlay2': '#9d8ec8', '--ctp-overlay1': '#8a7db8', '--ctp-overlay0': '#776daa',
-      '--ctp-surface2': '#3e3060', '--ctp-surface1': '#312550', '--ctp-surface0': '#271d42',
-      '--ctp-base': '#1e1535', '--ctp-mantle': '#160f2a', '--ctp-crust': '#100a20',
-    },
-  },
-  {
-    name: 'mint',
-    vars: {
-      '--ctp-text': '#8be0cc', '--ctp-subtext1': '#91d7e3', '--ctp-subtext0': '#a6e4b8',
-      '--ctp-overlay2': '#6db8a8', '--ctp-overlay1': '#5da89a', '--ctp-overlay0': '#4d988c',
-      '--ctp-surface2': '#2a4d48', '--ctp-surface1': '#20403a', '--ctp-surface0': '#18352e',
-      '--ctp-base': '#0e2822', '--ctp-mantle': '#081e19', '--ctp-crust': '#041510',
-    },
-  },
-  {
-    name: 'sunset',
-    vars: {
-      '--ctp-text': '#f5b07f', '--ctp-subtext1': '#eed49f', '--ctp-subtext0': '#f0c6a0',
-      '--ctp-overlay2': '#d49870', '--ctp-overlay1': '#c48a62', '--ctp-overlay0': '#b47c55',
-      '--ctp-surface2': '#4d3322', '--ctp-surface1': '#40291a', '--ctp-surface0': '#352012',
-      '--ctp-base': '#2a180c', '--ctp-mantle': '#201008', '--ctp-crust': '#180a04',
-    },
-  },
-  {
-    name: 'ocean',
-    vars: {
-      '--ctp-text': '#8ab8f4', '--ctp-subtext1': '#91c4e3', '--ctp-subtext0': '#a0b8f0',
-      '--ctp-overlay2': '#7098d0', '--ctp-overlay1': '#6088c0', '--ctp-overlay0': '#5078b0',
-      '--ctp-surface2': '#2a3550', '--ctp-surface1': '#202c44', '--ctp-surface0': '#182438',
-      '--ctp-base': '#0e1a2e', '--ctp-mantle': '#081222', '--ctp-crust': '#040c18',
-    },
-  },
-] as const
-
-type PaletteVarKey = keyof (typeof WHIMSICAL_PALETTES)[number]['vars']
-const ALL_PALETTE_VARS: PaletteVarKey[] = [
-  ...new Set(WHIMSICAL_PALETTES.flatMap((p) => Object.keys(p.vars))),
-] as PaletteVarKey[]
-
-function applyWhimsicalPalette() {
-  const palette = WHIMSICAL_PALETTES[Math.floor(Math.random() * WHIMSICAL_PALETTES.length)]!
-  const el = document.documentElement
-  for (const [prop, value] of Object.entries(palette.vars)) {
-    el.style.setProperty(prop, value)
-  }
-}
-
-function clearWhimsicalPalette() {
-  const el = document.documentElement
-  for (const prop of ALL_PALETTE_VARS) {
-    el.style.removeProperty(prop)
+    case 'sans-serif': return runtimeConfig.appearance.fonts.sansSerif
+    case 'comical': return runtimeConfig.appearance.fonts.comical
+    default: return runtimeConfig.appearance.fonts.serif
   }
 }
 
 const STORAGE_KEY = `${runtimeConfig.app.storageNamespace}:settings`
+const THEME_VARIABLES = [
+  ...new Set(
+    Object.values(runtimeConfig.appearance.themes)
+      .flatMap((theme) => Object.keys(theme.colors)),
+  ),
+]
 
 interface Settings {
   theme: Theme
@@ -104,7 +41,7 @@ interface Settings {
 
 function defaultSettings(): Settings {
   return {
-    theme: 'dark',
+    theme: 'system',
     fontSize: 24,
     lineSpacing: 1.7,
     font: 'serif',
@@ -118,11 +55,11 @@ function defaultSettings(): Settings {
 }
 
 function isTheme(value: unknown): value is Theme {
-  return value === 'light' || value === 'dark' || value === 'whimsical'
+  return value === 'system' || value === 'light' || value === 'dark'
 }
 
 function isFont(value: unknown): value is Font {
-  return value === 'serif' || value === 'sans-serif' || value === 'comic-sans'
+  return value === 'serif' || value === 'sans-serif' || value === 'comical'
 }
 
 function isProofreadingMode(value: unknown): value is ProofreadingMode {
@@ -168,46 +105,67 @@ function loadSettings(): Settings {
   return defaultSettings()
 }
 
+function supportsSystemTheme(): boolean {
+  return typeof window.matchMedia === 'function'
+}
+
+function systemPrefersDark(): boolean {
+  return supportsSystemTheme() && window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+function resolveTheme(theme: Theme): ResolvedTheme {
+  if (theme === 'light' || theme === 'dark') return theme
+  return systemPrefersDark() ? 'dark' : 'light'
+}
+
+function applyTheme(theme: Theme) {
+  const resolvedTheme = resolveTheme(theme)
+  const root = document.documentElement
+  const themeConfig = runtimeConfig.appearance.themes[resolvedTheme]
+
+  for (const variable of THEME_VARIABLES) {
+    root.style.removeProperty(variable)
+  }
+
+  for (const [variable, color] of Object.entries(themeConfig.colors)) {
+    root.style.setProperty(variable, color)
+  }
+
+  root.style.colorScheme = themeConfig.colorScheme
+  root.setAttribute('data-theme', resolvedTheme)
+  root.setAttribute('data-theme-preference', theme)
+}
+
 export const useSettingsStore = defineStore('settings', () => {
   const settings = ref<Settings>(loadSettings())
-
-  // Apply a random whimsical palette on init if already in whimsical mode
-  if (settings.value.theme === 'whimsical') {
-    applyWhimsicalPalette()
-  }
+  const systemThemeQuery = supportsSystemTheme()
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : null
 
   watch(
     settings,
     (val) => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
-      document.documentElement.setAttribute('data-theme', val.theme)
+      applyTheme(val.theme)
     },
     { deep: true, immediate: true },
   )
 
-  let fontBeforeWhimsical: Font | null = null
+  const handleSystemThemeChange = () => {
+    if (settings.value.theme === 'system') {
+      applyTheme('system')
+    }
+  }
 
-  // Restore saved pre-whimsical font on init
-  const FONT_BEFORE_KEY = `${runtimeConfig.app.storageNamespace}:fontBeforeWhimsical`
-  if (settings.value.theme === 'whimsical') {
-    const saved = localStorage.getItem(FONT_BEFORE_KEY)
-    if (saved) fontBeforeWhimsical = saved as Font
+  if (systemThemeQuery) {
+    if (typeof systemThemeQuery.addEventListener === 'function') {
+      systemThemeQuery.addEventListener('change', handleSystemThemeChange)
+    } else if (typeof systemThemeQuery.addListener === 'function') {
+      systemThemeQuery.addListener(handleSystemThemeChange)
+    }
   }
 
   function setTheme(theme: Theme) {
-    if (theme === 'whimsical') {
-      fontBeforeWhimsical = settings.value.font
-      localStorage.setItem(FONT_BEFORE_KEY, fontBeforeWhimsical)
-      settings.value.font = 'comic-sans'
-      applyWhimsicalPalette()
-    } else {
-      if (settings.value.theme === 'whimsical' && fontBeforeWhimsical) {
-        settings.value.font = fontBeforeWhimsical
-      }
-      fontBeforeWhimsical = null
-      localStorage.removeItem(FONT_BEFORE_KEY)
-      clearWhimsicalPalette()
-    }
     settings.value.theme = theme
   }
 
@@ -220,10 +178,6 @@ export const useSettingsStore = defineStore('settings', () => {
   }
 
   function setFont(font: Font) {
-    if (settings.value.theme === 'whimsical' && font !== 'comic-sans') {
-      fontBeforeWhimsical = font
-      localStorage.setItem(FONT_BEFORE_KEY, font)
-    }
     settings.value.font = font
   }
 


### PR DESCRIPTION
## Why
Theme and font behavior was hardcoded in the frontend, which made branding and UX customization require code changes. This change makes appearance configurable through runtime env config, matching the existing schema-config approach.

## What changed
- Added `VITE_THEME_CONFIG` parsing/validation in frontend runtime config, requiring `light` and `dark` theme definitions when set.
- Added `VITE_FONT_CONFIG` parsing/validation, requiring `sansSerif`, `serif`, and `comical` font families when set.
- Refactored settings theme handling to support `system`, `light`, and `dark` only.
- Removed whimsical theme support and palette randomization logic.
- Updated settings UI options to `System`, `Light`, `Dark`, and `Serif`, `Sans-serif`, `Comical`.
- Updated early theme initialization logic to resolve system preference and robustly read namespaced settings keys.
- Updated docs and env examples to document the new runtime appearance configuration.
- Added/updated runtime and settings tests to cover defaults, validation, and normalization behavior.

## Notes for review
- Theme variables are now applied dynamically from runtime config and mapped to resolved theme (`light`/`dark`) even when the preference is `system`.
- Existing stored legacy values (`whimsical`, `comic-sans`) are normalized back to supported defaults.

## Validation
- Frontend: lint, type-check, build, tests
- API: build, tests