### PR TITLE
fix: link bubble menu hover detection

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -255,10 +255,17 @@ function getCaretTop(): number | null {
 
 let hoveredLinkRange: { from: number; to: number } | null = null
 
+function toElement(target: EventTarget | null): Element | null {
+  if (target instanceof Element) return target
+  if (target instanceof Node) return target.parentElement
+  return null
+}
+
 function setHoverLinkSelection(target: EventTarget | null): boolean {
   const editor = tiptap.value
-  if (!editor || !(target instanceof Element)) return false
-  const anchor = target.closest('.ProseMirror a')
+  const element = toElement(target)
+  if (!editor || !element) return false
+  const anchor = element.closest('.ProseMirror a')
   if (!(anchor instanceof HTMLAnchorElement)) return false
 
   const pos = editor.view.posAtDOM(anchor, 0)
@@ -405,7 +412,8 @@ const tiptap = useEditor({
         return false
       },
       mouseout(_view, event) {
-        if (!(event.relatedTarget instanceof Element) || !event.relatedTarget.closest('.ProseMirror a')) {
+        const relatedElement = toElement(event.relatedTarget)
+        if (!relatedElement || !relatedElement.closest('.ProseMirror a')) {
           clearHoverLinkSelection()
         }
         return false


### PR DESCRIPTION
## Why
When hovering a link in the editor, the bubble menu could fail to appear, which blocked users from editing an existing URL in place.

## What changed
This updates the link-hover selection logic in `HomeView.vue` to normalize mouse event targets before resolving the hovered anchor. In practice, it now handles cases where browser mouse events originate from text nodes instead of elements.

## Result
Hovering link text reliably selects the link mark range again, so the link bubble menu appears consistently and users can edit URLs without deleting and recreating links.