### PR TITLE
Refactor font loading to Fontsource and rename handwriting setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Both frontend and API use typed runtime configuration so you can customize schem
 | `VITE_SANITY_API_VERSION` | No | `2024-01-01` |
 | `VITE_SANITY_SCHEMA_CONFIG` | No | JSON schema config. If unset, the frontend uses a built-in single-type default equivalent to `blog` / `title` / `body` / `slug` / `publishedAt`. |
 | `VITE_THEME_CONFIG` | No | JSON theme config for `light` and `dark` themes. If unset, the frontend uses built-in Catppuccin Latte (light) and Macchiato (dark). |
-| `VITE_FONT_CONFIG` | No | JSON font-family config. If set, it must provide `sansSerif`, `serif`, and `comical`. |
+| `VITE_FONT_CONFIG` | No | JSON font-family config. If set, it must provide `sansSerif`, `serif`, and `handwriting`. |
 | `VITE_SANITY_DRAFT_PREFIX` | No | `drafts.` (must end with `.`) |
 | `VITE_AUTH_PROVIDER` | No | `swa` (`swa` or `api`) |
 | `VITE_AUTH_CURRENT_USER_PATH` | No | `/.auth/me` for `swa`, `/api/me` for `api` |
@@ -170,11 +170,43 @@ Validation is fail-fast: invalid or missing required settings throw explicit run
 
 ```json
 {
-  "sansSerif": "system-ui, -apple-system, sans-serif",
-  "serif": "'Lora', Georgia, serif",
-  "comical": "'Comic Sans MS', cursive"
+  "sansSerif": "'Atkinson Hyperlegible', system-ui, sans-serif",
+  "serif": "'Domine', Georgia, serif",
+  "handwriting": "'Gloria Hallelujah', cursive"
 }
 ```
+
+Default font stacks (when `VITE_FONT_CONFIG` is unset):
+
+- `sansSerif`: `'Atkinson Hyperlegible', system-ui, -apple-system, BlinkMacSystemFont, sans-serif`
+- `serif`: `'Domine', Georgia, 'Times New Roman', serif`
+- `handwriting`: `'Gloria Hallelujah', 'Comic Sans MS', 'Comic Sans', cursive`
+
+### Fontsource usage
+
+The app bundles default fonts locally with [Fontsource](https://fontsource.org), so it does not fetch fonts from Google Fonts CDN.
+
+If you want custom fonts:
+
+1. Install the package(s), for example:
+
+   ```sh
+   cd app && npm install @fontsource/ibm-plex-serif @fontsource/public-sans @fontsource/caveat
+   ```
+
+2. Import the font CSS in `app/src/main.ts`, for example:
+
+   ```ts
+   import '@fontsource/ibm-plex-serif/400.css'
+   import '@fontsource/public-sans/400.css'
+   import '@fontsource/caveat/400.css'
+   ```
+
+3. Point `VITE_FONT_CONFIG` to those family names:
+
+   ```env
+   VITE_FONT_CONFIG={"sansSerif":"'Public Sans', system-ui, sans-serif","serif":"'IBM Plex Serif', Georgia, serif","handwriting":"'Caveat', cursive"}
+   ```
 
 When schema config is set, each type must declare `name`, `titleField`, `bodyField`, `slugField`, and `publishedAtField`. The old single-type mapping variables are no longer used as fallbacks. If schema config is unset, the app falls back to this built-in default:
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -7,7 +7,7 @@ VITE_SANITY_DATASET=dev
 # Optional UI theme config JSON. If unset, the built-in Catppuccin light/dark themes are used.
 # VITE_THEME_CONFIG={"light":{"colorScheme":"light","colors":{"--ctp-base":"#eff1f5","--ctp-text":"#4c4f69"}},"dark":{"colorScheme":"dark","colors":{"--ctp-base":"#24273a","--ctp-text":"#cad3f5"}}}
 # Optional font-family config JSON. If set, all three keys are required.
-# VITE_FONT_CONFIG={"sansSerif":"system-ui, -apple-system, sans-serif","serif":"'Lora', Georgia, serif","comical":"'Comic Sans MS', cursive"}
+# VITE_FONT_CONFIG={"sansSerif":"'Atkinson Hyperlegible', system-ui, sans-serif","serif":"'Domine', Georgia, serif","handwriting":"'Gloria Hallelujah', cursive"}
 VITE_SANITY_DRAFT_PREFIX=drafts.
 # Optional auth provider/runtime contract
 VITE_AUTH_PROVIDER=swa

--- a/app/index.html
+++ b/app/index.html
@@ -31,10 +31,6 @@
     <meta name="twitter:description" content="Earnesty is a clean, distraction-free writing app. Write, save, and revisit your work in a calm and focused environment.">
     <meta name="twitter:image" content="https://write.liasis.dev/og-image.png">
 
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,9 @@
       "version": "2.0.0",
       "dependencies": {
         "@catppuccin/palette": "^1.8.0",
+        "@fontsource/atkinson-hyperlegible": "^5.2.8",
+        "@fontsource/domine": "^5.2.8",
+        "@fontsource/gloria-hallelujah": "^5.2.6",
         "@microsoft/applicationinsights-web": "^3.4.2",
         "@sanity/client": "^7.23.0",
         "@tiptap/extension-code-block-lowlight": "^3.27.1",
@@ -1023,6 +1026,33 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/atkinson-hyperlegible": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-5.2.8.tgz",
+      "integrity": "sha512-HciLcJ5DIK/OVOdo71EbEN4NnvDFlp6/SpAxtcbWf2aAdcsOuPqITxj5KNEXb48qSPSdnnZdGGnSJChPKi3/bA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/domine": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/domine/-/domine-5.2.8.tgz",
+      "integrity": "sha512-sXSyFCJpQdEyanqBqGV6RnQSVneI5xXnXgSm54vSjTOSbaHpvU1Nv9iR7vWY/sESO3JPJJudMRUpJa8ZQOBuPA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/gloria-hallelujah": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/gloria-hallelujah/-/gloria-hallelujah-5.2.8.tgz",
+      "integrity": "sha512-GkIdkqC5eZbUX1jidQtoOdD7JAIq5pU5YzldX6uEcStNMrboXVnH1lafHJNLKrmufxEk7Tq3wg7hmI4kOlcJag==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "@catppuccin/palette": "^1.8.0",
+    "@fontsource/atkinson-hyperlegible": "^5.2.8",
+    "@fontsource/domine": "^5.2.8",
+    "@fontsource/gloria-hallelujah": "^5.2.6",
     "@microsoft/applicationinsights-web": "^3.4.2",
     "@sanity/client": "^7.23.0",
     "@tiptap/extension-code-block-lowlight": "^3.27.1",

--- a/app/public/staticwebapp.config.json
+++ b/app/public/staticwebapp.config.json
@@ -28,7 +28,7 @@
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "Referrer-Policy": "strict-origin-when-cross-origin",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://cdn.sanity.io data:; connect-src 'self' https://*.sanity.io https://dc.services.visualstudio.com https://*.in.applicationinsights.azure.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://cdn.sanity.io data:; connect-src 'self' https://*.sanity.io https://dc.services.visualstudio.com https://*.in.applicationinsights.azure.com; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()"
   },
   "mimeTypes": {

--- a/app/src/components/SettingsModal.vue
+++ b/app/src/components/SettingsModal.vue
@@ -30,7 +30,7 @@ const themes: { value: Theme; label: string }[] = [
 const fonts: { value: Font; label: string }[] = [
   { value: 'serif', label: 'Serif' },
   { value: 'sans-serif', label: 'Sans-serif' },
-  { value: 'comical', label: 'Comical' },
+  { value: 'handwriting', label: 'Handwriting' },
 ]
 
 const fontSizeLabels: Record<number, string> = {

--- a/app/src/config/__tests__/runtime.test.ts
+++ b/app/src/config/__tests__/runtime.test.ts
@@ -26,9 +26,9 @@ describe('createRuntimeConfig', () => {
     expect(config.app.storageNamespace).toBe('earnesty')
     expect(config.appearance.themes.light.colorScheme).toBe('light')
     expect(config.appearance.themes.dark.colorScheme).toBe('dark')
-    expect(config.appearance.fonts.sansSerif).toContain('system-ui')
-    expect(config.appearance.fonts.serif).toContain('Lora')
-    expect(config.appearance.fonts.comical).toContain('Comic Sans')
+    expect(config.appearance.fonts.sansSerif).toContain('Atkinson Hyperlegible')
+    expect(config.appearance.fonts.serif).toContain('Domine')
+    expect(config.appearance.fonts.handwriting).toContain('Gloria Hallelujah')
   })
 
   it('throws when VITE_SANITY_PROJECT_ID is missing outside test mode', () => {
@@ -138,7 +138,7 @@ describe('createRuntimeConfig', () => {
       VITE_FONT_CONFIG: JSON.stringify({
         sansSerif: 'Inter, system-ui, sans-serif',
         serif: 'Merriweather, serif',
-        comical: '"Comic Neue", cursive',
+        handwriting: '"Comic Neue", cursive',
       }),
     }))
 
@@ -147,8 +147,20 @@ describe('createRuntimeConfig', () => {
     expect(config.appearance.fonts).toEqual({
       sansSerif: 'Inter, system-ui, sans-serif',
       serif: 'Merriweather, serif',
-      comical: '"Comic Neue", cursive',
+      handwriting: '"Comic Neue", cursive',
     })
+  })
+
+  it('accepts legacy comical key as handwriting alias', () => {
+    const config = createRuntimeConfig(makeEnv({
+      VITE_FONT_CONFIG: JSON.stringify({
+        sansSerif: 'Inter, system-ui, sans-serif',
+        serif: 'Merriweather, serif',
+        comical: '"Comic Neue", cursive',
+      }),
+    }))
+
+    expect(config.appearance.fonts.handwriting).toBe('"Comic Neue", cursive')
   })
 
   it('throws when custom theme config is missing required themes', () => {
@@ -169,6 +181,6 @@ describe('createRuntimeConfig', () => {
         sansSerif: 'Inter, sans-serif',
         serif: 'Merriweather, serif',
       }),
-    }))).toThrow('VITE_FONT_CONFIG.comical')
+    }))).toThrow('VITE_FONT_CONFIG.handwriting')
   })
 })

--- a/app/src/config/runtime.ts
+++ b/app/src/config/runtime.ts
@@ -70,7 +70,7 @@ export interface ThemeRuntimeConfig {
 export interface FontRuntimeConfig {
   sansSerif: string
   serif: string
-  comical: string
+  handwriting: string
 }
 
 const DEFAULT_CONTENT_FIELDS = {
@@ -147,9 +147,9 @@ const DEFAULT_THEME_CONFIG: Record<ResolvedTheme, ThemeRuntimeConfig> = {
 }
 
 const DEFAULT_FONT_CONFIG: FontRuntimeConfig = {
-  sansSerif: 'system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
-  serif: '\'Lora\', Georgia, \'Times New Roman\', serif',
-  comical: '\'Comic Sans MS\', \'Comic Sans\', cursive',
+  sansSerif: '\'Atkinson Hyperlegible\', system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+  serif: '\'Domine\', Georgia, \'Times New Roman\', serif',
+  handwriting: '\'Gloria Hallelujah\', \'Comic Sans MS\', \'Comic Sans\', cursive',
 }
 
 function envString(value: unknown): string | undefined {
@@ -233,7 +233,9 @@ interface ThemeInput {
 interface FontConfigInput {
   sansSerif?: unknown
   serif?: unknown
+  // Legacy alias retained for backwards compatibility with older env files.
   comical?: unknown
+  handwriting?: unknown
 }
 
 function defaultMetadataFields(type: {
@@ -513,10 +515,12 @@ function readFontConfig(value: string | undefined): FontRuntimeConfig {
     })
   }
 
+  const handwriting = parsed.handwriting ?? parsed.comical
+
   return {
     sansSerif: readRequiredFontFamily(parsed.sansSerif, 'VITE_FONT_CONFIG.sansSerif'),
     serif: readRequiredFontFamily(parsed.serif, 'VITE_FONT_CONFIG.serif'),
-    comical: readRequiredFontFamily(parsed.comical, 'VITE_FONT_CONFIG.comical'),
+    handwriting: readRequiredFontFamily(handwriting, 'VITE_FONT_CONFIG.handwriting'),
   }
 }
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,3 +1,8 @@
+import '@fontsource/domine/400.css'
+import '@fontsource/domine/700.css'
+import '@fontsource/atkinson-hyperlegible/400.css'
+import '@fontsource/atkinson-hyperlegible/700.css'
+import '@fontsource/gloria-hallelujah/400.css'
 import './assets/main.css'
 
 import { createApp } from 'vue'

--- a/app/src/stores/__tests__/settings.test.ts
+++ b/app/src/stores/__tests__/settings.test.ts
@@ -68,6 +68,15 @@ describe('settings store proofreading controls', () => {
     expect(store.settings.editorLanguage).toBe('en')
   })
 
+  it('maps legacy comical font preference to handwriting', () => {
+    storage.setItem(SETTINGS_KEY, JSON.stringify({
+      font: 'comical',
+    }))
+
+    const store = useSettingsStore()
+    expect(store.settings.font).toBe('handwriting')
+  })
+
   it('persists proofreading changes', async () => {
     const store = useSettingsStore()
     store.setProofreadingMode('advanced')

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import { runtimeConfig, type ResolvedTheme } from '../config/runtime'
 
 export type Theme = 'system' | 'light' | 'dark'
-export type Font = 'serif' | 'sans-serif' | 'comical'
+export type Font = 'serif' | 'sans-serif' | 'handwriting'
 export type ProofreadingMode = 'off' | 'native' | 'advanced'
 export type AutocorrectSetting = 'on' | 'off'
 
@@ -13,7 +13,7 @@ export const CONTENT_WIDTHS = [50, 60, 70] as const
 export function fontFamilyFor(font: Font): string {
   switch (font) {
     case 'sans-serif': return runtimeConfig.appearance.fonts.sansSerif
-    case 'comical': return runtimeConfig.appearance.fonts.comical
+    case 'handwriting': return runtimeConfig.appearance.fonts.handwriting
     default: return runtimeConfig.appearance.fonts.serif
   }
 }
@@ -59,7 +59,7 @@ function isTheme(value: unknown): value is Theme {
 }
 
 function isFont(value: unknown): value is Font {
-  return value === 'serif' || value === 'sans-serif' || value === 'comical'
+  return value === 'serif' || value === 'sans-serif' || value === 'handwriting'
 }
 
 function isProofreadingMode(value: unknown): value is ProofreadingMode {
@@ -79,11 +79,13 @@ function normalizeEditorLanguage(value: unknown): string {
 
 function normalizeSettings(raw: Partial<Settings> | null | undefined): Settings {
   const defaults = defaultSettings()
+  const storedFont = (raw as { font?: unknown } | null | undefined)?.font
+  const rawFont = storedFont === 'comical' ? 'handwriting' : storedFont
   return {
     theme: isTheme(raw?.theme) ? raw.theme : defaults.theme,
     fontSize: typeof raw?.fontSize === 'number' ? raw.fontSize : defaults.fontSize,
     lineSpacing: typeof raw?.lineSpacing === 'number' ? raw.lineSpacing : defaults.lineSpacing,
-    font: isFont(raw?.font) ? raw.font : defaults.font,
+    font: isFont(rawFont) ? rawFont : defaults.font,
     contentWidth: typeof raw?.contentWidth === 'number' ? raw.contentWidth : defaults.contentWidth,
     proofreadingMode: isProofreadingMode(raw?.proofreadingMode) ? raw.proofreadingMode : defaults.proofreadingMode,
     spellcheck: typeof raw?.spellcheck === 'boolean' ? raw.spellcheck : defaults.spellcheck,


### PR DESCRIPTION
## Why
The app currently fetched its serif default from Google Fonts, which adds an external dependency and network requests we want to avoid. This change moves default font loading to local Fontsource packages and clarifies the runtime font contract in docs.

## What changed
- Replaced Google Fonts usage in `app/index.html` with local Fontsource imports in `app/src/main.ts`.
- Added Fontsource dependencies for the selected defaults:
  - Serif: `Domine`
  - Sans-serif: `Atkinson Hyperlegible`
  - Handwriting: `Gloria Hallelujah`
- Updated runtime defaults and renamed the font config key from `comical` to `handwriting`.
- Kept backward compatibility by accepting legacy `comical` values from `VITE_FONT_CONFIG` and stored user settings.
- Updated settings UI label from `Comical` to `Handwriting`.
- Updated CSP to remove Google Fonts origins now that fonts are served locally.
- Updated `README.md` and `.env.example` to document default font stacks and Fontsource customization steps.

## Notes for review
- The rename is behavior-safe for existing users because old saved/configured `comical` values are mapped to `handwriting` at runtime.
- `app/package-lock.json` changed due to the new Fontsource dependencies.