### PR TITLE
chore: help modal links for markdown docs and repository

### DIFF
--- a/app/public/docs/markdown.md
+++ b/app/public/docs/markdown.md
@@ -1,0 +1,97 @@
+# Markdown syntax
+
+Earnesty uses a focused subset of Markdown. Below is everything you can use.
+
+---
+
+## Headings
+
+```
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+```
+
+---
+
+## Emphasis
+
+```
+**bold**
+*italic*
+~~strikethrough~~
+```
+
+---
+
+## Lists
+
+Unordered — use `-` or `*`:
+
+```
+- First item
+- Second item
+  - Nested item
+```
+
+Ordered:
+
+```
+1. First item
+2. Second item
+```
+
+---
+
+## Blockquote
+
+```
+> This is a blockquote.
+```
+
+---
+
+## Code
+
+Inline: wrap in backticks.
+
+```
+Use `console.log()` to debug.
+```
+
+Fenced code block (optionally with a language for syntax highlighting):
+
+````
+```javascript
+const greeting = 'Hello, world!'
+```
+````
+
+---
+
+## Links
+
+```
+[Link text](https://example.com)
+```
+
+URLs typed or pasted directly are auto-linked.
+
+---
+
+## Images
+
+```
+![Alt text](https://example.com/image.png)
+```
+
+---
+
+## Horizontal rule
+
+```
+---
+```

--- a/app/src/components/HelpModal.vue
+++ b/app/src/components/HelpModal.vue
@@ -17,11 +17,20 @@ defineEmits<{ close: [] }>()
     <p class="intro">
       Markdown is supported for formatting.
       <a
-        href="https://github.com/sjovang/earnesty/blob/main/docs/markdown.md"
+        href="/docs/markdown.md"
         target="_blank"
         rel="noopener noreferrer"
         class="docs-link"
       >See which syntax is available →</a>
+    </p>
+    <p class="intro">
+      Project source code:
+      <a
+        href="https://github.com/sjovang/earnesty"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="docs-link"
+      >https://github.com/sjovang/earnesty</a>
     </p>
   </BaseModal>
 </template>


### PR DESCRIPTION
## Why
The Help modal pointed users to markdown documentation on GitHub instead of in the app, and it did not include a direct link to the project repository.

## What changed
- Updated the "See which syntax is available" link to open `/docs/markdown.md` so markdown guidance is served from the app.
- Added a new Help modal link to the repository: `https://github.com/sjovang/earnesty`.
- Added `app/public/docs/markdown.md` so the markdown guide is available at the in-app path.

## Notes
This keeps user-facing writing help inside the app while still exposing the project source link in the modal.