### PR TITLE
feat: Add document deletion support

### DIFF
--- a/app/api/src/__tests__/deleteDocument.test.ts
+++ b/app/api/src/__tests__/deleteDocument.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import type { HttpRequest, HttpResponseInit } from '@azure/functions'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+
+const { getHandler, setHandler } = vi.hoisted(() => {
+  let _handler: ((req: HttpRequest) => Promise<HttpResponseInit>) | null = null
+  return {
+    getHandler: () => _handler!,
+    setHandler: (h: (req: HttpRequest) => Promise<HttpResponseInit>) => {
+      _handler = h
+    },
+  }
+})
+
+vi.mock('@azure/functions', () => ({
+  app: {
+    http: (_name: string, config: { handler: (req: HttpRequest) => Promise<HttpResponseInit> }) => {
+      setHandler(config.handler)
+    },
+  },
+}))
+
+vi.mock('../shared.js', () => ({
+  getSanityClient: vi.fn(),
+  requireAuthenticatedPrincipal: vi.fn(),
+}))
+
+beforeAll(async () => {
+  await import('../functions/deleteDocument.js')
+})
+
+const DRAFT_ID = 'drafts.550e8400-e29b-41d4-a716-446655440000'
+const PUBLISHED_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+const VALID_PRINCIPAL = {
+  identityProvider: 'aad',
+  userId: 'user-123',
+  userDetails: 'test@example.com',
+  userRoles: ['authenticated'],
+  claims: [],
+}
+
+function makeRequest(options: { params?: Record<string, string> }): HttpRequest {
+  return {
+    headers: { get: (_name: string) => null },
+    params: options.params ?? {},
+  } as unknown as HttpRequest
+}
+
+function makeDeleteClient(options?: {
+  existingIds?: string[]
+  commitThrows?: boolean
+}) {
+  const existingIds = new Set(options?.existingIds ?? [DRAFT_ID, PUBLISHED_ID])
+  const commit = options?.commitThrows
+    ? vi.fn().mockRejectedValue(new Error('Transaction failed'))
+    : vi.fn().mockResolvedValue({ transactionId: 'tx-delete-123' })
+  const deleteFn = vi.fn()
+  const transaction = vi.fn().mockReturnValue({
+    delete: deleteFn.mockImplementation(() => ({ delete: deleteFn, commit })),
+  })
+  const getDocument = vi.fn().mockImplementation(async (id: string) => (
+    existingIds.has(id) ? { _id: id, _type: 'blog' } : null
+  ))
+
+  return { getDocument, transaction, deleteFn, commit }
+}
+
+describe('deleteDocument handler', () => {
+  beforeEach(() => {
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({ principal: VALID_PRINCIPAL })
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(requireAuthenticatedPrincipal).mockReturnValue({
+      response: { status: 401, jsonBody: { error: 'Not authenticated' } },
+    })
+
+    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+    expect(res.status).toBe(401)
+    expect(res.jsonBody).toEqual({ error: 'Not authenticated' })
+  })
+
+  it('returns 400 when document ID is missing', async () => {
+    const res = await getHandler()(makeRequest({ params: {} }))
+    expect(res.status).toBe(400)
+    expect(res.jsonBody).toEqual({ error: 'Missing document ID' })
+  })
+
+  it('returns 404 when neither the draft nor published document exists', async () => {
+    const { getDocument, transaction } = makeDeleteClient({ existingIds: [] })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+    expect(res.status).toBe(404)
+    expect(res.jsonBody).toEqual({ error: 'Document not found' })
+  })
+
+  it('deletes both draft and published documents when given a draft ID', async () => {
+    const { getDocument, transaction, deleteFn, commit } = makeDeleteClient()
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+
+    expect(getDocument).toHaveBeenCalledWith(DRAFT_ID)
+    expect(getDocument).toHaveBeenCalledWith(PUBLISHED_ID)
+    expect(transaction).toHaveBeenCalled()
+    expect(deleteFn).toHaveBeenNthCalledWith(1, DRAFT_ID)
+    expect(deleteFn).toHaveBeenNthCalledWith(2, PUBLISHED_ID)
+    expect(commit).toHaveBeenCalled()
+    expect(res.status).toBe(204)
+  })
+
+  it('deletes both draft and published documents when given a published ID', async () => {
+    const { getDocument, transaction, deleteFn } = makeDeleteClient()
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+
+    await getHandler()(makeRequest({ params: { id: PUBLISHED_ID } }))
+
+    expect(getDocument).toHaveBeenCalledWith(DRAFT_ID)
+    expect(getDocument).toHaveBeenCalledWith(PUBLISHED_ID)
+    expect(deleteFn).toHaveBeenNthCalledWith(1, DRAFT_ID)
+    expect(deleteFn).toHaveBeenNthCalledWith(2, PUBLISHED_ID)
+  })
+
+  it('deletes only the draft when no published sibling exists', async () => {
+    const { getDocument, transaction, deleteFn, commit } = makeDeleteClient({ existingIds: [DRAFT_ID] })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+
+    expect(deleteFn).toHaveBeenCalledTimes(1)
+    expect(deleteFn).toHaveBeenCalledWith(DRAFT_ID)
+    expect(commit).toHaveBeenCalled()
+    expect(res.status).toBe(204)
+  })
+
+  it('deletes only the published document when no draft sibling exists', async () => {
+    const { getDocument, transaction, deleteFn, commit } = makeDeleteClient({ existingIds: [PUBLISHED_ID] })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: PUBLISHED_ID } }))
+
+    expect(deleteFn).toHaveBeenCalledTimes(1)
+    expect(deleteFn).toHaveBeenCalledWith(PUBLISHED_ID)
+    expect(commit).toHaveBeenCalled()
+    expect(res.status).toBe(204)
+  })
+
+  it('returns 502 when the Sanity transaction fails', async () => {
+    const { getDocument, transaction } = makeDeleteClient({ commitThrows: true })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+    expect(res.status).toBe(502)
+    expect(res.jsonBody).toEqual({ error: 'Failed to delete document' })
+  })
+})

--- a/app/api/src/functions/deleteDocument.ts
+++ b/app/api/src/functions/deleteDocument.ts
@@ -1,0 +1,55 @@
+import {
+  app,
+  type HttpRequest,
+  type HttpResponseInit,
+} from '@azure/functions'
+import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
+import { getApiRuntimeConfig, isDraftDocumentId, toPublishedDocumentId } from '../config/runtime.js'
+
+function relatedDocumentIds(id: string): [string, string] {
+  if (isDraftDocumentId(id)) {
+    return [id, toPublishedDocumentId(id)]
+  }
+
+  const draftId = `${getApiRuntimeConfig().content.draftPrefix}${id}`
+  return [draftId, id]
+}
+
+app.http('deleteDocument', {
+  methods: ['DELETE'],
+  authLevel: 'anonymous',
+  route: 'sanity/documents/{id}',
+  handler: async (
+    request: HttpRequest,
+  ): Promise<HttpResponseInit> => {
+    const auth = requireAuthenticatedPrincipal(request)
+    if ('response' in auth) return auth.response
+
+    const id = request.params['id']
+    if (!id) {
+      return { status: 400, jsonBody: { error: 'Missing document ID' } }
+    }
+
+    try {
+      const client = getSanityClient()
+      const candidateIds = relatedDocumentIds(id)
+      const existingDocuments = await Promise.all(candidateIds.map((documentId) => client.getDocument(documentId)))
+      const existingIds = candidateIds.filter((_documentId, index) => Boolean(existingDocuments[index]))
+
+      if (existingIds.length === 0) {
+        return { status: 404, jsonBody: { error: 'Document not found' } }
+      }
+
+      const transaction = existingIds.reduce(
+        (builder, documentId) => builder.delete(documentId),
+        client.transaction(),
+      )
+
+      await transaction.commit()
+      return { status: 204 }
+    } catch (err) {
+      console.error('[deleteDocument]', err)
+      return { status: 502, jsonBody: { error: 'Failed to delete document' } }
+    }
+  },
+})

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -57,6 +57,10 @@ function escapeHtml(str: string): string {
     .replace(/"/g, '&quot;')
 }
 
+function baseDocumentId(id: string): string {
+  return id.startsWith(draftPrefix) ? id.slice(draftPrefix.length) : id
+}
+
 const canPublish = computed(() =>
   auth.isAuthenticated
   && !!editorStore.activeDocument
@@ -178,6 +182,18 @@ async function doPublish() {
   }
 }
 
+function onDocumentDeleted(doc: ContentDocument) {
+  if (editorStore.activeDocument && baseDocumentId(editorStore.activeDocument._id) === baseDocumentId(doc._id)) {
+    editorStore.discardPendingSave?.()
+    editorStore.resetToPlaceholder()
+    showPublishModal.value = false
+    showMetadataModal.value = false
+    publishError.value = ''
+    metadataError.value = ''
+  }
+  trackEvent('document_deleted', { documentId: doc._id })
+}
+
 onMounted(async () => {
   await auth.initialize()
 })
@@ -206,6 +222,7 @@ onMounted(async () => {
   <RouterView />
   <OpenDocumentModal
     v-if="showOpen"
+    @delete="onDocumentDeleted"
     @close="showOpen = false"
     @select="onDocumentSelected"
   />

--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -4,16 +4,18 @@ import BaseModal from './BaseModal.vue'
 import { useDocuments } from '../composables/useBlogDocuments'
 import { extractPreview, type ContentDocument } from '../services/sanity'
 import { runtimeConfig } from '../config/runtime'
-import { clearRedirectTimestamp } from '../services/api'
+import { apiDeleteDocument, clearRedirectTimestamp } from '../services/api'
+import { trackException } from '../services/appInsights'
 import { useAuthStore } from '../stores/auth'
 
 const emit = defineEmits<{
   close: []
   select: [doc: ContentDocument]
+  delete: [doc: ContentDocument]
 }>()
 
 const auth = useAuthStore()
-const { documents, loading, error, isAuthError } = useDocuments()
+const { documents, loading, error, isAuthError, removeDocument } = useDocuments()
 const draftPrefix = runtimeConfig.content.draftPrefix
 
 // ── Search & sort ─────────────────────────────────────────────────────────────
@@ -23,6 +25,8 @@ type DocStatus = 'draft' | 'published' | 'changed'
 const search = ref('')
 const sortBy = ref<SortKey>('newest')
 const hoveredId = ref<string | null>(null)
+const deletingId = ref<string | null>(null)
+const deleteError = ref('')
 
 const sortOptions: { value: SortKey; label: string }[] = [
   { value: 'newest',     label: 'Newest' },
@@ -79,6 +83,8 @@ const filtered = computed(() => {
   return list
 })
 
+const canDeleteDocuments = computed(() => auth.isAuthenticated)
+
 const statusMeta: Record<DocStatus, { label: string; color: string }> = {
   draft:     { label: 'Draft — not yet published',         color: 'var(--ctp-yellow)' },
   published: { label: 'Published',                         color: 'var(--ctp-green)'  },
@@ -91,9 +97,39 @@ function formatDate(iso: string) {
   })
 }
 
+function toMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message
+  return fallback
+}
+
 function select(doc: ContentDocument) {
+  if (deletingId.value) return
   emit('select', doc)
   emit('close')
+}
+
+async function remove(doc: ContentDocument) {
+  if (!canDeleteDocuments.value || deletingId.value) return
+  const title = doc.title?.trim() || 'Untitled'
+  const confirmed = window.confirm(`Delete "${title}"? This removes the document from Sanity.`)
+  if (!confirmed) return
+
+  deleteError.value = ''
+  deletingId.value = doc._id
+
+  try {
+    await apiDeleteDocument(doc._id)
+    removeDocument(doc._id)
+    emit('delete', doc)
+  } catch (error) {
+    deleteError.value = toMessage(error, 'Failed to delete document. Please retry.')
+    trackException(error instanceof Error ? error : new Error(String(error)), {
+      action: 'delete_document',
+      documentId: doc._id,
+    })
+  } finally {
+    deletingId.value = null
+  }
 }
 
 function signIn() {
@@ -158,10 +194,16 @@ function signIn() {
     >
       {{ error }}
     </div>
+    <div
+      v-if="deleteError && !loading && !isAuthError && !error"
+      class="status status--error status--inline"
+    >
+      {{ deleteError }}
+    </div>
 
     <!-- Empty search result -->
     <div
-      v-else-if="!filtered.length"
+      v-if="!loading && !isAuthError && !error && !filtered.length"
       class="status"
     >
       {{ documents.length ? 'No documents match your search.' : 'No documents found in this dataset.' }}
@@ -169,13 +211,15 @@ function signIn() {
 
     <!-- Document list -->
     <ul
-      v-else
+      v-else-if="!loading && !isAuthError && !error"
       class="doc-list"
     >
       <li
         v-for="{ doc, status } in filtered"
         :key="doc._id"
         class="doc-list__item"
+        :class="{ 'doc-list__item--busy': deletingId === doc._id }"
+        :aria-busy="deletingId === doc._id ? 'true' : undefined"
         @click="select(doc)"
         @mouseenter="hoveredId = doc._id"
         @mouseleave="hoveredId = null"
@@ -249,6 +293,15 @@ function signIn() {
 
           <span class="doc-list__title">{{ doc.title ?? '(Untitled)' }}</span>
           <span class="doc-list__date">{{ formatDate(doc._updatedAt) }}</span>
+          <button
+            v-if="canDeleteDocuments"
+            class="doc-list__delete"
+            :disabled="!!deletingId"
+            :aria-label="`Delete ${doc.title ?? 'Untitled'}`"
+            @click.stop="remove(doc)"
+          >
+            {{ deletingId === doc._id ? 'Deleting…' : 'Delete' }}
+          </button>
         </div>
         <Transition name="preview-fade">
           <p
@@ -328,6 +381,10 @@ function signIn() {
   padding: 2rem 0;
 }
 
+.status--inline {
+  padding: 0 0 0.75rem;
+}
+
 .status--error { color: var(--ctp-red); }
 
 .status--auth {
@@ -374,6 +431,7 @@ function signIn() {
 }
 
 .doc-list__item:hover { background: var(--ctp-surface0); }
+.doc-list__item--busy { cursor: progress; }
 
 .doc-list__main {
   display: flex;
@@ -404,6 +462,33 @@ function signIn() {
   color: var(--ctp-subtext1);
   font-size: 0.75rem;
   flex-shrink: 0;
+}
+
+.doc-list__delete {
+  border: none;
+  background: transparent;
+  color: var(--ctp-red);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.45rem;
+  border-radius: 5px;
+  cursor: pointer;
+  opacity: 0.72;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.doc-list__item:hover .doc-list__delete,
+.doc-list__item:focus-within .doc-list__delete,
+.doc-list__delete:disabled {
+  opacity: 1;
+}
+
+.doc-list__delete:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--ctp-red) 14%, transparent);
+}
+
+.doc-list__delete:disabled {
+  cursor: progress;
 }
 
 .doc-list__preview {

--- a/app/src/composables/useBlogDocuments.ts
+++ b/app/src/composables/useBlogDocuments.ts
@@ -1,6 +1,7 @@
 import { ref, onMounted } from 'vue'
 import type { ContentDocument } from '../services/sanity'
 import { apiListDocuments, AuthError } from '../services/api'
+import { runtimeConfig } from '../config/runtime'
 import { useAuthStore } from '../stores/auth'
 
 export function useDocuments() {
@@ -9,8 +10,15 @@ export function useDocuments() {
   const error = ref<string | null>(null)
   const isAuthError = ref(false)
   const auth = useAuthStore()
+  const draftPrefix = runtimeConfig.content.draftPrefix
 
-  onMounted(async () => {
+  function baseDocumentId(id: string): string {
+    return id.startsWith(draftPrefix) ? id.slice(draftPrefix.length) : id
+  }
+
+  async function refreshDocuments() {
+    error.value = null
+    isAuthError.value = false
     try {
       documents.value = await apiListDocuments()
     } catch (e) {
@@ -26,9 +34,18 @@ export function useDocuments() {
     } finally {
       loading.value = false
     }
+  }
+
+  function removeDocument(id: string) {
+    const deletedBaseId = baseDocumentId(id)
+    documents.value = documents.value.filter((doc) => baseDocumentId(doc._id) !== deletedBaseId)
+  }
+
+  onMounted(() => {
+    void refreshDocuments()
   })
 
-  return { documents, loading, error, isAuthError }
+  return { documents, loading, error, isAuthError, refreshDocuments, removeDocument }
 }
 
 /** @deprecated Use {@link useDocuments} instead. */

--- a/app/src/services/__tests__/api.test.ts
+++ b/app/src/services/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
+  apiDeleteDocument,
   apiSaveDocument,
   apiPublishDocument,
   apiCreateDraft,
@@ -206,6 +207,43 @@ describe('apiPublishDocument', () => {
   it('throws on a non-2xx response', async () => {
     mockFetch.mockResolvedValue(makeResponse(400, { error: 'Document is not a draft' }))
     await expect(apiPublishDocument('not-a-draft')).rejects.toThrow('Document is not a draft')
+  })
+})
+
+// ── apiDeleteDocument ───────────────────────────────────────────────────────────
+
+describe('apiDeleteDocument', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('sends a DELETE request to the document endpoint', async () => {
+    mockFetch.mockResolvedValue(makeResponse(204))
+    await apiDeleteDocument('drafts.doc-123')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/sanity/documents/drafts.doc-123',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
+  it('encodes special characters in the document ID', async () => {
+    mockFetch.mockResolvedValue(makeResponse(204))
+    await apiDeleteDocument('drafts.some/id')
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain(encodeURIComponent('drafts.some/id'))
+  })
+
+  it('resolves without a value on 204 No Content', async () => {
+    mockFetch.mockResolvedValue(makeResponse(204))
+    const result = await apiDeleteDocument('drafts.doc-123')
+    expect(result).toBeUndefined()
+  })
+
+  it('throws on a non-2xx response', async () => {
+    mockFetch.mockResolvedValue(makeResponse(404, { error: 'Document not found' }))
+    await expect(apiDeleteDocument('missing-id')).rejects.toThrow('Document not found')
   })
 })
 

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -150,6 +150,13 @@ export async function apiPublishDocument(
   )
 }
 
+/** Deletes a document and any paired draft/published sibling via the API proxy. */
+export async function apiDeleteDocument(id: string): Promise<void> {
+  await apiFetch<void>(`/api/sanity/documents/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  })
+}
+
 /** Uploads an image file to Sanity via the API proxy. */
 export async function apiUploadImage(file: File): Promise<ImageAsset> {
   const form = new FormData()

--- a/app/src/stores/editor.ts
+++ b/app/src/stores/editor.ts
@@ -116,6 +116,7 @@ export const useEditorStore = defineStore('editor', () => {
 
   /** Registered by HomeView to flush pending autosave before publish. */
   const flushSave = shallowRef<(() => Promise<void>) | null>(null)
+  const discardPendingSave = shallowRef<(() => void) | null>(null)
 
   function openDocument(doc: ContentDocument, html?: string) {
     activeDocument.value = doc
@@ -129,6 +130,8 @@ export const useEditorStore = defineStore('editor', () => {
     currentContent.value = ''
     pendingHtml.value = null
     meta.value = defaultMeta()
+    saveStatus.value = 'idle'
+    publishStatus.value = 'idle'
     localStorage.removeItem(SESSION_KEY)
     localStorage.removeItem(CONTENT_KEY)
   }
@@ -223,6 +226,7 @@ export const useEditorStore = defineStore('editor', () => {
     publishStatus,
     meta,
     flushSave,
+    discardPendingSave,
     openDocument,
     clearDocument,
     resetToPlaceholder,

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -73,6 +73,11 @@ editorStore.flushSave = async () => {
   if (latestJson) await doAutosave()
   if (currentSavePromise) await currentSavePromise
 }
+editorStore.discardPendingSave = () => {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = null
+  latestJson = null
+}
 
 // ── Image picker ───────────────────────────────────────────────────────────────
 const showImagePicker = ref(false)
@@ -466,6 +471,7 @@ onBeforeUnmount(() => {
   tiptap.value?.destroy()
   if (saveTimer) clearTimeout(saveTimer)
   editorStore.flushSave = null
+  editorStore.discardPendingSave = null
 })
 
 // ── Load document from store ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why
Writers could create, edit, and publish documents, but they had no way to remove content they no longer wanted. This change adds a complete delete flow so documents can be removed from the app instead of requiring manual cleanup in Sanity.

## What changed
- add a delete API endpoint that removes the requested document and its paired draft or published sibling when present
- add frontend delete support in the document picker, including optimistic list updates and clearing the editor when the active document is removed
- show the delete action only for signed-in users and guard the handler the same way
- add API and frontend coverage for the new delete behavior

## Notes for reviewers
The delete endpoint treats draft and published documents as a pair, so deleting either side cleans up the other when it exists. This keeps the picker and editor from surfacing stale content after a delete.