### PR TITLE
docs: require conventional commit prefixes in PR titles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ User settings are stored in the browser's local storage, allowing for a personal
 
 All work is done in feature branches and merged into `main` through a pull request. Branch names should follow the pattern `feature/<short-description>`. Direct commits to `main` are not allowed.
 
-Pull requests must not be merged until all CI checks pass. Pull requests are always created as drafts and must be reviewed and approved by the repository owner before merging — Copilot will not approve or merge them.
+Pull requests must use a Conventional Commit prefix in the title (for example `feat:` or `fix:`). Pull requests must not be merged until all CI checks pass. Pull requests are always created as drafts and must be reviewed and approved by the repository owner before merging — Copilot will not approve or merge them.
 
 ## Commits
 


### PR DESCRIPTION
## Why
Commit messages already have to follow Conventional Commits for release-please, but the repository instructions did not say the same for pull request titles. Adding that guidance keeps PR naming consistent with the existing workflow.

## What changed
- update `.github/copilot-instructions.md` to require a Conventional Commit prefix in PR titles, for example `feat:` or `fix:`
- keep the rule next to the existing pull request workflow requirements so it is easy to find

## Notes for reviewers
This is a documentation-only change.