### PR TITLE
fix: restore menu bar auto-hide on mouseover

### DIFF
--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -439,12 +439,14 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   left: 0;
   right: 0;
   z-index: 100;
-  opacity: 0.72;
-  transition: opacity 0.2s ease;
+  transform: translateY(calc(-100% + 0.375rem));
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .menubar:hover,
 .menubar:focus-within {
+  transform: translateY(0);
   opacity: 1;
 }
 
@@ -712,6 +714,7 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
     top: var(--space-xs);
     left: var(--space-xs);
     right: var(--space-xs);
+    transform: none;
     opacity: 0.85;
   }
 


### PR DESCRIPTION
The menu bar stopped auto-hiding and remained visible, which breaks the distraction-free writing UI. This change restores the intended behavior so the bar is only visible when the user interacts with it.

## What changed
- Hide the desktop menu bar by default using an upward translate and zero opacity.
- Reveal the bar on `:hover` and `:focus-within` to preserve keyboard accessibility.
- Keep mobile behavior unchanged by disabling the desktop hide transform inside the mobile breakpoint.

## Notes for reviewers
- This is a CSS-only behavior fix in `AppMenuBar.vue` and does not change menu actions or state handling.