### PR TITLE
fix: show markdown syntax help inline in help modal

### DIFF
--- a/app/src/components/HelpModal.vue
+++ b/app/src/components/HelpModal.vue
@@ -1,8 +1,35 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import BaseModal from './BaseModal.vue'
 import { runtimeConfig } from '../config/runtime'
 
 defineEmits<{ close: [] }>()
+
+const markdownHelp = ref('')
+const markdownHelpError = ref('')
+const showMarkdownHelp = ref(false)
+
+async function toggleMarkdownHelp(): Promise<void> {
+  if (showMarkdownHelp.value) {
+    showMarkdownHelp.value = false
+    return
+  }
+
+  markdownHelpError.value = ''
+
+  if (!markdownHelp.value) {
+    try {
+      const response = await fetch('/docs/markdown.md')
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      markdownHelp.value = await response.text()
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error)
+      markdownHelpError.value = `Markdown help could not be loaded (${details}).`
+    }
+  }
+
+  showMarkdownHelp.value = true
+}
 </script>
 
 <template>
@@ -16,13 +43,24 @@ defineEmits<{ close: [] }>()
     </p>
     <p class="intro">
       Markdown is supported for formatting.
-      <a
-        href="/docs/markdown.md"
-        target="_blank"
-        rel="noopener noreferrer"
+      <button
+        type="button"
         class="docs-link"
-      >See which syntax is available →</a>
+        @click="toggleMarkdownHelp"
+      >
+        {{ showMarkdownHelp ? 'Hide markdown syntax help' : 'See which syntax is available →' }}
+      </button>
     </p>
+    <p
+      v-if="showMarkdownHelp && markdownHelpError"
+      class="markdown-help-error"
+    >
+      {{ markdownHelpError }}
+    </p>
+    <pre
+      v-else-if="showMarkdownHelp"
+      class="markdown-help"
+    >{{ markdownHelp }}</pre>
     <p class="intro">
       Project source code:
       <a
@@ -44,13 +82,39 @@ defineEmits<{ close: [] }>()
 }
 
 .docs-link {
+  background: none;
+  border: none;
   color: var(--ctp-blue);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
   text-decoration: none;
   white-space: nowrap;
 }
 
 .docs-link:hover {
   text-decoration: underline;
+}
+
+.markdown-help {
+  background: var(--ctp-surface0);
+  border-radius: 0.5rem;
+  color: var(--ctp-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin: 0 0 1.25rem;
+  max-height: min(50vh, 32rem);
+  overflow: auto;
+  padding: 0.75rem;
+  white-space: pre-wrap;
+}
+
+.markdown-help-error {
+  color: var(--ctp-red);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0 0 1.25rem;
 }
 
 </style>


### PR DESCRIPTION
## Why
The help modal's markdown syntax link opened `/docs/markdown.md` as a file download, which interrupts the writing flow and takes users out of the app.

## What changed
This updates the help modal to display markdown syntax help inline:

- Replaced the external anchor with an in-app toggle button.
- Added lazy loading for `/docs/markdown.md` using `fetch` the first time the help is opened.
- Rendered the loaded markdown text inside the modal in a scrollable, readable `<pre>` block.
- Added inline error feedback when the markdown help file cannot be loaded.
- Styled the new button to match the existing link appearance and theme tokens.

## Notes for review
This keeps the existing help content in `app/public/docs/markdown.md` and only changes how it is presented to users.