### PR TITLE
fix: widen menubar hover activation zone

### DIFF
--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -444,6 +444,15 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
+.menubar::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 0.875rem;
+}
+
 .menubar:hover,
 .menubar:focus-within {
   transform: translateY(0);
@@ -716,6 +725,10 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
     right: var(--space-xs);
     transform: none;
     opacity: 0.85;
+  }
+
+  .menubar::after {
+    display: none;
   }
 
   .menubar__inner {


### PR DESCRIPTION
## Why
The menubar reveal area at the top of the editor was too narrow, making it hard to activate reliably with mouse movement.

## What changed
- Added an invisible hover activation strip below the hidden desktop menubar using `::after`.
- Kept the menubar reveal behavior unchanged (`:hover` / `:focus-within`), but made it easier to trigger.
- Disabled the activation strip on mobile to avoid interfering with touch interactions.

## Notes for review
This is a focused CSS-only usability fix in `AppMenuBar.vue` with no behavior changes outside menubar activation hit area.