### PR TITLE
fix: improve menubar reveal hit area

### DIFF
--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -439,7 +439,7 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   left: 0;
   right: 0;
   z-index: 100;
-  transform: translateY(calc(-100% + 0.375rem));
+  transform: translateY(-100%);
   opacity: 0;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
@@ -450,7 +450,7 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   top: 100%;
   left: 0;
   right: 0;
-  height: 0.875rem;
+  height: 3.5rem;
 }
 
 .menubar:hover,

--- a/app/src/components/AppMenuBar.vue
+++ b/app/src/components/AppMenuBar.vue
@@ -444,6 +444,15 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
+.menubar::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 0.875rem;
+}
+
 .menubar:hover,
 .menubar:focus-within {
   transform: translateY(0);
@@ -716,6 +725,10 @@ function mobileEmit(event: 'new' | 'open' | 'metadata' | 'publish' | 'help' | 's
     right: var(--space-xs);
     transform: none;
     opacity: 0.85;
+  }
+
+  .menubar::after {
+    display: none;
   }
 
   .menubar__inner {


### PR DESCRIPTION
## Why
Revealing the top menubar still required a very narrow cursor target, which made it frustrating to activate consistently.

## What changed
- Increased the desktop hover activation zone under the hidden menubar to `3.5rem`.
- Removed the always-visible top sliver by fully hiding the menubar when collapsed (`translateY(-100%)`).
- Kept mobile behavior unchanged by disabling the extra hover zone at the mobile breakpoint.

## Notes for review
This is a CSS-only interaction tweak in `AppMenuBar.vue` to make desktop menubar reveal easier without changing menu actions or layout.