### PR TITLE
fix: make delete action unpublish published documents

### DIFF
--- a/app/api/src/__tests__/deleteDocument.test.ts
+++ b/app/api/src/__tests__/deleteDocument.test.ts
@@ -47,23 +47,38 @@ function makeRequest(options: { params?: Record<string, string> }): HttpRequest 
   } as unknown as HttpRequest
 }
 
+function makeDocument(id: string, title: string) {
+  return { _id: id, _type: 'blog', title, _createdAt: '2026-01-01', _updatedAt: '2026-01-01' }
+}
+
 function makeDeleteClient(options?: {
-  existingIds?: string[]
+  draft?: Record<string, unknown> | null
+  published?: Record<string, unknown> | null
   commitThrows?: boolean
+  deleteThrows?: boolean
 }) {
-  const existingIds = new Set(options?.existingIds ?? [DRAFT_ID, PUBLISHED_ID])
+  const docs = new Map<string, Record<string, unknown>>()
+  if (options?.draft) docs.set(DRAFT_ID, options.draft)
+  if (options?.published) docs.set(PUBLISHED_ID, options.published)
+
   const commit = options?.commitThrows
     ? vi.fn().mockRejectedValue(new Error('Transaction failed'))
     : vi.fn().mockResolvedValue({ transactionId: 'tx-delete-123' })
-  const deleteFn = vi.fn()
-  const transaction = vi.fn().mockReturnValue({
-    delete: deleteFn.mockImplementation(() => ({ delete: deleteFn, commit })),
-  })
-  const getDocument = vi.fn().mockImplementation(async (id: string) => (
-    existingIds.has(id) ? { _id: id, _type: 'blog' } : null
-  ))
+  const tx = {
+    createOrReplace: vi.fn(),
+    delete: vi.fn(),
+    commit,
+  }
+  tx.createOrReplace.mockImplementation(() => tx)
+  tx.delete.mockImplementation(() => tx)
 
-  return { getDocument, transaction, deleteFn, commit }
+  const transaction = vi.fn().mockReturnValue(tx)
+  const getDocument = vi.fn().mockImplementation(async (id: string) => docs.get(id) ?? null)
+  const deleteDoc = options?.deleteThrows
+    ? vi.fn().mockRejectedValue(new Error('Delete failed'))
+    : vi.fn().mockResolvedValue({ _id: DRAFT_ID })
+
+  return { getDocument, transaction, tx, deleteDoc, commit }
 }
 
 describe('deleteDocument handler', () => {
@@ -87,71 +102,82 @@ describe('deleteDocument handler', () => {
     expect(res.jsonBody).toEqual({ error: 'Missing document ID' })
   })
 
-  it('returns 404 when neither the draft nor published document exists', async () => {
-    const { getDocument, transaction } = makeDeleteClient({ existingIds: [] })
-    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+  it('returns 404 when neither draft nor published document exists', async () => {
+    const { getDocument, transaction, deleteDoc } = makeDeleteClient()
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction, delete: deleteDoc } as never)
 
     const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
     expect(res.status).toBe(404)
     expect(res.jsonBody).toEqual({ error: 'Document not found' })
   })
 
-  it('deletes both draft and published documents when given a draft ID', async () => {
-    const { getDocument, transaction, deleteFn, commit } = makeDeleteClient()
-    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+  it('permanently deletes a draft-only document', async () => {
+    const draft = makeDocument(DRAFT_ID, 'Draft title')
+    const { getDocument, transaction, deleteDoc, tx } = makeDeleteClient({ draft })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction, delete: deleteDoc } as never)
 
     const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
 
-    expect(getDocument).toHaveBeenCalledWith(DRAFT_ID)
-    expect(getDocument).toHaveBeenCalledWith(PUBLISHED_ID)
-    expect(transaction).toHaveBeenCalled()
-    expect(deleteFn).toHaveBeenNthCalledWith(1, DRAFT_ID)
-    expect(deleteFn).toHaveBeenNthCalledWith(2, PUBLISHED_ID)
-    expect(commit).toHaveBeenCalled()
+    expect(deleteDoc).toHaveBeenCalledWith(DRAFT_ID)
+    expect(transaction).not.toHaveBeenCalled()
+    expect(tx.createOrReplace).not.toHaveBeenCalled()
     expect(res.status).toBe(204)
   })
 
-  it('deletes both draft and published documents when given a published ID', async () => {
-    const { getDocument, transaction, deleteFn } = makeDeleteClient()
-    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
-
-    await getHandler()(makeRequest({ params: { id: PUBLISHED_ID } }))
-
-    expect(getDocument).toHaveBeenCalledWith(DRAFT_ID)
-    expect(getDocument).toHaveBeenCalledWith(PUBLISHED_ID)
-    expect(deleteFn).toHaveBeenNthCalledWith(1, DRAFT_ID)
-    expect(deleteFn).toHaveBeenNthCalledWith(2, PUBLISHED_ID)
-  })
-
-  it('deletes only the draft when no published sibling exists', async () => {
-    const { getDocument, transaction, deleteFn, commit } = makeDeleteClient({ existingIds: [DRAFT_ID] })
-    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
-
-    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
-
-    expect(deleteFn).toHaveBeenCalledTimes(1)
-    expect(deleteFn).toHaveBeenCalledWith(DRAFT_ID)
-    expect(commit).toHaveBeenCalled()
-    expect(res.status).toBe(204)
-  })
-
-  it('deletes only the published document when no draft sibling exists', async () => {
-    const { getDocument, transaction, deleteFn, commit } = makeDeleteClient({ existingIds: [PUBLISHED_ID] })
-    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+  it('unpublishes a published-only document by moving it to draft', async () => {
+    const published = makeDocument(PUBLISHED_ID, 'Published title')
+    const { getDocument, transaction, deleteDoc, tx, commit } = makeDeleteClient({ published })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction, delete: deleteDoc } as never)
 
     const res = await getHandler()(makeRequest({ params: { id: PUBLISHED_ID } }))
 
-    expect(deleteFn).toHaveBeenCalledTimes(1)
-    expect(deleteFn).toHaveBeenCalledWith(PUBLISHED_ID)
+    expect(transaction).toHaveBeenCalled()
+    expect(tx.createOrReplace).toHaveBeenCalledWith(expect.objectContaining({
+      _id: DRAFT_ID,
+      _type: 'blog',
+      title: 'Published title',
+    }))
+    expect(tx.delete).toHaveBeenCalledWith(PUBLISHED_ID)
     expect(commit).toHaveBeenCalled()
+    expect(deleteDoc).not.toHaveBeenCalled()
     expect(res.status).toBe(204)
   })
 
-  it('returns 502 when the Sanity transaction fails', async () => {
-    const { getDocument, transaction } = makeDeleteClient({ commitThrows: true })
-    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction } as never)
+  it('replaces existing draft with published content when both versions exist', async () => {
+    const draft = makeDocument(DRAFT_ID, 'Draft changes')
+    const published = makeDocument(PUBLISHED_ID, 'Published baseline')
+    const { getDocument, transaction, deleteDoc, tx } = makeDeleteClient({ draft, published })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction, delete: deleteDoc } as never)
 
     const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+
+    expect(tx.createOrReplace).toHaveBeenCalledWith(expect.objectContaining({
+      _id: DRAFT_ID,
+      title: 'Published baseline',
+    }))
+    expect(tx.delete).toHaveBeenCalledWith(PUBLISHED_ID)
+    expect(deleteDoc).not.toHaveBeenCalled()
+    expect(res.status).toBe(204)
+  })
+
+  it('returns 502 when unpublish transaction fails', async () => {
+    const published = makeDocument(PUBLISHED_ID, 'Published title')
+    const { getDocument, transaction, deleteDoc } = makeDeleteClient({ published, commitThrows: true })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction, delete: deleteDoc } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: PUBLISHED_ID } }))
+
+    expect(res.status).toBe(502)
+    expect(res.jsonBody).toEqual({ error: 'Failed to delete document' })
+  })
+
+  it('returns 502 when deleting draft-only document fails', async () => {
+    const draft = makeDocument(DRAFT_ID, 'Draft title')
+    const { getDocument, transaction, deleteDoc } = makeDeleteClient({ draft, deleteThrows: true })
+    vi.mocked(getSanityClient).mockReturnValue({ getDocument, transaction, delete: deleteDoc } as never)
+
+    const res = await getHandler()(makeRequest({ params: { id: DRAFT_ID } }))
+
     expect(res.status).toBe(502)
     expect(res.jsonBody).toEqual({ error: 'Failed to delete document' })
   })

--- a/app/api/src/functions/deleteDocument.ts
+++ b/app/api/src/functions/deleteDocument.ts
@@ -6,13 +6,15 @@ import {
 import { getSanityClient, requireAuthenticatedPrincipal } from '../shared.js'
 import { getApiRuntimeConfig, isDraftDocumentId, toPublishedDocumentId } from '../config/runtime.js'
 
-function relatedDocumentIds(id: string): [string, string] {
+function toRelatedDocumentIds(id: string): { draftId: string; publishedId: string } {
   if (isDraftDocumentId(id)) {
-    return [id, toPublishedDocumentId(id)]
+    return { draftId: id, publishedId: toPublishedDocumentId(id) }
   }
 
-  const draftId = `${getApiRuntimeConfig().content.draftPrefix}${id}`
-  return [draftId, id]
+  return {
+    draftId: `${getApiRuntimeConfig().content.draftPrefix}${id}`,
+    publishedId: id,
+  }
 }
 
 app.http('deleteDocument', {
@@ -32,20 +34,27 @@ app.http('deleteDocument', {
 
     try {
       const client = getSanityClient()
-      const candidateIds = relatedDocumentIds(id)
-      const existingDocuments = await Promise.all(candidateIds.map((documentId) => client.getDocument(documentId)))
-      const existingIds = candidateIds.filter((_documentId, index) => Boolean(existingDocuments[index]))
+      const { draftId, publishedId } = toRelatedDocumentIds(id)
+      const [draft, published] = await Promise.all([
+        client.getDocument(draftId),
+        client.getDocument(publishedId),
+      ])
 
-      if (existingIds.length === 0) {
+      if (!draft && !published) {
         return { status: 404, jsonBody: { error: 'Document not found' } }
       }
 
-      const transaction = existingIds.reduce(
-        (builder, documentId) => builder.delete(documentId),
-        client.transaction(),
-      )
+      if (published) {
+        const { _id: _publishedId, _rev: _publishedRev, ...fields } = published
+        await client
+          .transaction()
+          .createOrReplace({ ...fields, _id: draftId })
+          .delete(publishedId)
+          .commit()
+      } else if (draft) {
+        await client.delete(draftId)
+      }
 
-      await transaction.commit()
       return { status: 204 }
     } catch (err) {
       console.error('[deleteDocument]', err)

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -61,6 +61,10 @@ function baseDocumentId(id: string): string {
   return id.startsWith(draftPrefix) ? id.slice(draftPrefix.length) : id
 }
 
+function toDraftDocumentId(id: string): string {
+  return `${draftPrefix}${baseDocumentId(id)}`
+}
+
 const canPublish = computed(() =>
   auth.isAuthenticated
   && !!editorStore.activeDocument
@@ -194,6 +198,28 @@ function onDocumentDeleted(doc: ContentDocument) {
   trackEvent('document_deleted', { documentId: doc._id })
 }
 
+async function onDocumentUnpublished(doc: ContentDocument) {
+  trackEvent('document_unpublished', { documentId: doc._id })
+  if (!editorStore.activeDocument || baseDocumentId(editorStore.activeDocument._id) !== baseDocumentId(doc._id)) {
+    return
+  }
+
+  try {
+    const draft = await apiGetDocument(toDraftDocumentId(doc._id))
+    if (!draft) {
+      editorStore.discardPendingSave?.()
+      editorStore.resetToPlaceholder()
+      return
+    }
+    editorStore.openDocument(draft)
+  } catch (err) {
+    trackException(err instanceof Error ? err : new Error(String(err)), {
+      action: 'open_unpublished_draft',
+      documentId: doc._id,
+    })
+  }
+}
+
 onMounted(async () => {
   await auth.initialize()
 })
@@ -225,6 +251,7 @@ onMounted(async () => {
     @delete="onDocumentDeleted"
     @close="showOpen = false"
     @select="onDocumentSelected"
+    @unpublish="onDocumentUnpublished"
   />
   <NewDocumentModal
     v-if="showNew"

--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -12,10 +12,11 @@ const emit = defineEmits<{
   close: []
   select: [doc: ContentDocument]
   delete: [doc: ContentDocument]
+  unpublish: [doc: ContentDocument]
 }>()
 
 const auth = useAuthStore()
-const { documents, loading, error, isAuthError, removeDocument } = useDocuments()
+const { documents, loading, error, isAuthError, removeDocument, refreshDocuments } = useDocuments()
 const draftPrefix = runtimeConfig.content.draftPrefix
 
 // ── Search & sort ─────────────────────────────────────────────────────────────
@@ -108,10 +109,39 @@ function select(doc: ContentDocument) {
   emit('close')
 }
 
-async function remove(doc: ContentDocument) {
+function actionForStatus(status: DocStatus): 'delete' | 'unpublish' {
+  return status === 'draft' ? 'delete' : 'unpublish'
+}
+
+function actionLabel(status: DocStatus): string {
+  return actionForStatus(status) === 'delete' ? 'Delete' : 'Unpublish'
+}
+
+function inProgressLabel(status: DocStatus): string {
+  return actionForStatus(status) === 'delete' ? 'Deleting…' : 'Unpublishing…'
+}
+
+function confirmationMessage(title: string, status: DocStatus): string {
+  if (status === 'draft') {
+    return `Delete "${title}"? This permanently deletes the draft and cannot be undone.`
+  }
+  if (status === 'changed') {
+    return `Unpublish "${title}"? This replaces the current draft with the published version and removes the published document.`
+  }
+  return `Unpublish "${title}"? This moves the published document back to draft status.`
+}
+
+function fallbackError(status: DocStatus): string {
+  return actionForStatus(status) === 'delete'
+    ? 'Failed to delete draft. Please retry.'
+    : 'Failed to unpublish document. Please retry.'
+}
+
+async function remove(doc: ContentDocument, status: DocStatus) {
   if (!canDeleteDocuments.value || deletingId.value) return
   const title = doc.title?.trim() || 'Untitled'
-  const confirmed = window.confirm(`Delete "${title}"? This removes the document from Sanity.`)
+  const action = actionForStatus(status)
+  const confirmed = window.confirm(confirmationMessage(title, status))
   if (!confirmed) return
 
   deleteError.value = ''
@@ -119,12 +149,17 @@ async function remove(doc: ContentDocument) {
 
   try {
     await apiDeleteDocument(doc._id)
-    removeDocument(doc._id)
-    emit('delete', doc)
+    if (action === 'delete') {
+      removeDocument(doc._id)
+      emit('delete', doc)
+    } else {
+      await refreshDocuments()
+      emit('unpublish', doc)
+    }
   } catch (error) {
-    deleteError.value = toMessage(error, 'Failed to delete document. Please retry.')
+    deleteError.value = toMessage(error, fallbackError(status))
     trackException(error instanceof Error ? error : new Error(String(error)), {
-      action: 'delete_document',
+      action: action === 'delete' ? 'delete_document' : 'unpublish_document',
       documentId: doc._id,
     })
   } finally {
@@ -297,10 +332,10 @@ function signIn() {
             v-if="canDeleteDocuments"
             class="doc-list__delete"
             :disabled="!!deletingId"
-            :aria-label="`Delete ${doc.title ?? 'Untitled'}`"
-            @click.stop="remove(doc)"
+            :aria-label="`${actionLabel(status)} ${doc.title ?? 'Untitled'}`"
+            @click.stop="remove(doc, status)"
           >
-            {{ deletingId === doc._id ? 'Deleting…' : 'Delete' }}
+            {{ deletingId === doc._id ? inProgressLabel(status) : actionLabel(status) }}
           </button>
         </div>
         <Transition name="preview-fade">

--- a/app/src/components/__tests__/OpenDocumentModal.behavior.test.ts
+++ b/app/src/components/__tests__/OpenDocumentModal.behavior.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+describe('OpenDocumentModal delete/unpublish behavior', () => {
+  const testDir = dirname(fileURLToPath(import.meta.url))
+  const source = readFileSync(resolve(testDir, '../OpenDocumentModal.vue'), 'utf8')
+
+  it('maps draft status to Delete and non-draft statuses to Unpublish', () => {
+    expect(source).toMatch(/function actionForStatus\(status: DocStatus\): 'delete' \| 'unpublish'/)
+    expect(source).toMatch(/return status === 'draft' \? 'delete' : 'unpublish'/)
+  })
+
+  it('includes destructive confirmation copy for deleting drafts', () => {
+    expect(source).toContain('This permanently deletes the draft and cannot be undone.')
+  })
+
+  it('includes replacement warning when unpublishing changed documents', () => {
+    expect(source).toContain('This replaces the current draft with the published version')
+  })
+})

--- a/app/src/services/__tests__/api.test.ts
+++ b/app/src/services/__tests__/api.test.ts
@@ -227,6 +227,16 @@ describe('apiDeleteDocument', () => {
     )
   })
 
+  it('uses the same DELETE endpoint for published document IDs (unpublish flow)', async () => {
+    mockFetch.mockResolvedValue(makeResponse(204))
+    await apiDeleteDocument('doc-123')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/sanity/documents/doc-123',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
   it('encodes special characters in the document ID', async () => {
     mockFetch.mockResolvedValue(makeResponse(204))
     await apiDeleteDocument('drafts.some/id')


### PR DESCRIPTION
## Why
The open-document modal used a single Delete action that removed both draft and published variants, which made unpublishing impossible and could destroy content unexpectedly. This change makes the action state-aware so published content is moved back to draft, while draft-only content can still be permanently deleted.

## What changed
- Updated the `DELETE /api/sanity/documents/{id}` handler to branch by existing state:
  - draft only -> hard delete draft
  - published only -> unpublish by creating/replacing draft from published content and deleting published
  - draft + published -> replace draft with published content, then delete published
- Updated `OpenDocumentModal` to show status-based actions:
  - `Delete` for draft-only docs (irreversible confirmation)
  - `Unpublish` for published/changed docs with unpublish-specific confirmation text
- After unpublish, refreshed modal documents and emitted a dedicated `unpublish` event.
- Updated `App.vue` to handle unpublish for the active document by reopening the resulting draft version.
- Expanded tests for backend and frontend behavior, including a new modal behavior test for action mapping and confirmation copy.

## Notes for reviewers
For documents with both published and draft versions, unpublish now intentionally replaces current draft edits with the published version, matching the requested behavior.

## Validation
- `cd app/api && npm test`
- `cd app && npm test`
- `cd app && npx vitest run src/components/__tests__/OpenDocumentModal.behavior.test.ts`
- `pre-commit run`