### PR TITLE
fix: make unpublish action yellow in document modal

### DIFF
--- a/app/src/components/OpenDocumentModal.vue
+++ b/app/src/components/OpenDocumentModal.vue
@@ -330,7 +330,10 @@ function signIn() {
           <span class="doc-list__date">{{ formatDate(doc._updatedAt) }}</span>
           <button
             v-if="canDeleteDocuments"
-            class="doc-list__delete"
+            :class="[
+              'doc-list__delete',
+              { 'doc-list__delete--unpublish': actionForStatus(status) === 'unpublish' },
+            ]"
             :disabled="!!deletingId"
             :aria-label="`${actionLabel(status)} ${doc.title ?? 'Untitled'}`"
             @click.stop="remove(doc, status)"
@@ -520,6 +523,14 @@ function signIn() {
 
 .doc-list__delete:hover:not(:disabled) {
   background: color-mix(in srgb, var(--ctp-red) 14%, transparent);
+}
+
+.doc-list__delete--unpublish {
+  color: var(--ctp-yellow);
+}
+
+.doc-list__delete--unpublish:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--ctp-yellow) 14%, transparent);
 }
 
 .doc-list__delete:disabled {


### PR DESCRIPTION
The document modal currently uses the same red destructive styling for both Delete and Unpublish, which makes unpublish actions look more destructive than intended. This update aligns the UI with the intended semantics: unpublish is cautionary, delete remains destructive.

## What changed
- Added a conditional class on the action button in `OpenDocumentModal.vue` when the action is `unpublish`.
- Kept the default delete styling red.
- Added a yellow text and hover background style for the unpublish button variant.

This is a focused visual change only; action behavior and confirmation flows are unchanged.