### PR TITLE
fix: restore cursor position after link hover dismisses bubble menu

### DIFF
--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -259,6 +259,7 @@ function getCaretTop(): number | null {
 }
 
 let hoveredLinkRange: { from: number; to: number } | null = null
+let selectionBeforeHover: { from: number; to: number } | null = null
 
 function toElement(target: EventTarget | null): Element | null {
   if (target instanceof Element) return target
@@ -280,6 +281,12 @@ function setHoverLinkSelection(target: EventTarget | null): boolean {
   if (!range) return false
   if (hoveredLinkRange && hoveredLinkRange.from === range.from && hoveredLinkRange.to === range.to) return true
 
+  // Save original cursor position on first hover entry so we can restore it on leave.
+  if (!hoveredLinkRange) {
+    const sel = editor.state.selection
+    selectionBeforeHover = { from: sel.from, to: sel.to }
+  }
+
   hoveredLinkRange = { from: range.from, to: range.to }
   editor.view.dispatch(
     editor.state.tr
@@ -290,7 +297,21 @@ function setHoverLinkSelection(target: EventTarget | null): boolean {
 }
 
 function clearHoverLinkSelection() {
+  const editor = tiptap.value
+  if (editor && selectionBeforeHover) {
+    const { from, to } = selectionBeforeHover
+    try {
+      editor.view.dispatch(
+        editor.state.tr
+          .setSelection(TextSelection.create(editor.state.doc, from, to))
+          .setMeta('addToHistory', false),
+      )
+    } catch {
+      // Position may be out of range if the document changed while hovering; ignore.
+    }
+  }
   hoveredLinkRange = null
+  selectionBeforeHover = null
 }
 
 function scrollToCaret() {


### PR DESCRIPTION
## Why

When hovering a link, `setHoverLinkSelection` dispatches a `TextSelection` covering the full link range so `LinkBubbleMenu` can detect it via `isActive('link')`. But `clearHoverLinkSelection` only reset the `hoveredLinkRange` tracking variable — it never restored the editor's actual selection.

This left the link text permanently selected after the mouse left, causing the bubble menu to stay visible indefinitely and leaving the editor in a confused state where typing would replace the link text.

## What changed

- `setHoverLinkSelection` now saves the original cursor position into `selectionBeforeHover` on the first hover entry.
- `clearHoverLinkSelection` dispatches a restore transaction to put the cursor back where it was, then clears both tracking variables.
- A `try/catch` guards the restore dispatch in case the document changed while the mouse was over the link.

## Result

The link bubble menu now appears on hover and dismisses correctly on mouseout, without disturbing the user's cursor position.