### PR TITLE
fix: reset editor state for unauthenticated sessions

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -222,6 +222,9 @@ async function onDocumentUnpublished(doc: ContentDocument) {
 
 onMounted(async () => {
   await auth.initialize()
+  if (!auth.isAuthenticated) {
+    editorStore.resetToPlaceholder()
+  }
 })
 </script>
 


### PR DESCRIPTION
Users who open the app without being signed in should always land on the default writing view. Previously, cached editor state could still be restored in a fresh browser session, which exposed the last edited document content even when auth was missing.

## What changed
- After auth initialization in `App.vue`, the app now explicitly resets the editor store when no authenticated user is present.
- This reset clears persisted session and content cache and restores the placeholder intro state for signed-out users.

## Notes for reviewers
- The change is intentionally scoped to app bootstrap so authenticated flows continue to load normally, while unauthenticated startup is forced to the default view.