### PR TITLE
fix: restore link tooltip editing and add selection link creation

### DIFF
--- a/app/src/components/LinkBubbleMenu.vue
+++ b/app/src/components/LinkBubbleMenu.vue
@@ -9,10 +9,16 @@ const editing = ref(false)
 const urlInput = ref<HTMLInputElement | null>(null)
 const draftUrl = ref('')
 
+const linkActive = computed(() => props.editor.isActive('link'))
 const currentUrl = computed(() => props.editor.getAttributes('link').href ?? '')
+const hasTextSelection = computed(() => {
+  const { selection, doc } = props.editor.state
+  if (selection.empty) return false
+  return doc.textBetween(selection.from, selection.to, '', '').trim().length > 0
+})
 
 function shouldShow() {
-  return props.editor.isActive('link')
+  return linkActive.value || hasTextSelection.value
 }
 
 function truncate(url: string, max = 42) {
@@ -20,7 +26,7 @@ function truncate(url: string, max = 42) {
 }
 
 async function startEdit() {
-  draftUrl.value = currentUrl.value
+  draftUrl.value = currentUrl.value || 'https://'
   editing.value = true
   await nextTick()
   urlInput.value?.focus()
@@ -29,8 +35,13 @@ async function startEdit() {
 
 function applyUrl() {
   const url = draftUrl.value.trim()
-  if (url) {
-    props.editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run()
+  if (!url) return
+
+  const chain = props.editor.chain().focus()
+  if (linkActive.value) {
+    chain.extendMarkRange('link').setLink({ href: url }).run()
+  } else {
+    chain.setLink({ href: url }).run()
   }
   editing.value = false
 }
@@ -63,14 +74,72 @@ function onBubbleHide() {
   >
     <!-- View mode: show URL + actions -->
     <template v-if="!editing">
-      <span
-        class="link-bubble__url"
-        :title="currentUrl"
-      >{{ truncate(currentUrl) }}</span>
-      <div class="link-bubble__sep" />
+      <template v-if="linkActive">
+        <span
+          class="link-bubble__url"
+          :title="currentUrl"
+        >{{ truncate(currentUrl) }}</span>
+        <div class="link-bubble__sep" />
+        <button
+          class="link-bubble__btn"
+          title="Edit link"
+          @click="startEdit"
+        >
+          <svg
+            viewBox="0 0 12 12"
+            width="12"
+            height="12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M8 2l2 2-5.5 5.5H2.5V8L8 2z" />
+          </svg>
+        </button>
+        <button
+          class="link-bubble__btn"
+          title="Remove link"
+          @click="unlink"
+        >
+          <svg
+            viewBox="0 0 12 12"
+            width="12"
+            height="12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M4.5 7.5l3-3M2 10l1.5-1.5M8.5 3.5L10 2M5 4.5l-1.5 1A2.12 2.12 0 006.5 8.5l1-1.5M7 7.5l1.5-1A2.12 2.12 0 005.5 3.5L4.5 5" />
+          </svg>
+        </button>
+        <button
+          class="link-bubble__btn"
+          title="Open in new tab"
+          @click="openInTab"
+        >
+          <svg
+            viewBox="0 0 12 12"
+            width="12"
+            height="12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M5 2H2v8h8V7M7 2h3v3M10 2L6 6" />
+          </svg>
+        </button>
+      </template>
+
       <button
-        class="link-bubble__btn"
-        title="Edit link"
+        v-else
+        class="link-bubble__btn link-bubble__btn--add"
+        title="Add link"
         @click="startEdit"
       >
         <svg
@@ -83,44 +152,9 @@ function onBubbleHide() {
           stroke-linecap="round"
           stroke-linejoin="round"
         >
-          <path d="M8 2l2 2-5.5 5.5H2.5V8L8 2z" />
+          <path d="M4.8 7.2l2.4-2.4M3.5 8.5L2 10M8.5 3.5L10 2M5.2 4.8l-1.6 1.1A2.1 2.1 0 006.5 8.8l1.1-1.6M6.8 7.2l1.6-1.1A2.1 2.1 0 005.5 3.2L4.4 4.8" />
         </svg>
-      </button>
-      <button
-        class="link-bubble__btn"
-        title="Remove link"
-        @click="unlink"
-      >
-        <svg
-          viewBox="0 0 12 12"
-          width="12"
-          height="12"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.4"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M4.5 7.5l3-3M2 10l1.5-1.5M8.5 3.5L10 2M5 4.5l-1.5 1A2.12 2.12 0 006.5 8.5l1-1.5M7 7.5l1.5-1A2.12 2.12 0 005.5 3.5L4.5 5" />
-        </svg>
-      </button>
-      <button
-        class="link-bubble__btn"
-        title="Open in new tab"
-        @click="openInTab"
-      >
-        <svg
-          viewBox="0 0 12 12"
-          width="12"
-          height="12"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.4"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M5 2H2v8h8V7M7 2h3v3M10 2L6 6" />
-        </svg>
+        <span>Add link</span>
       </button>
     </template>
 
@@ -230,6 +264,12 @@ function onBubbleHide() {
 
 .link-bubble__btn--confirm:hover {
   color: var(--ctp-green);
+}
+
+.link-bubble__btn--add {
+  width: auto;
+  gap: 6px;
+  padding: 0 8px;
 }
 
 .link-bubble__input {

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -304,7 +304,6 @@ function clearHoverLinkSelection() {
   const editor = tiptap.value
   if (editor && selectionBeforeHover) {
     const { from, to } = selectionBeforeHover
-<<<<<<< HEAD
     const maxPos = editor.state.doc.content.size
     const safeFrom = Math.max(0, Math.min(from, maxPos))
     const safeTo = Math.max(0, Math.min(to, maxPos))
@@ -314,16 +313,6 @@ function clearHoverLinkSelection() {
           .setSelection(TextSelection.create(editor.state.doc, safeFrom, safeTo))
           .setMeta('addToHistory', false),
       )
-=======
-    try {
-      editor.view.dispatch(
-        editor.state.tr
-          .setSelection(TextSelection.create(editor.state.doc, from, to))
-          .setMeta('addToHistory', false),
-      )
-    } catch {
-      // Position may be out of range if the document changed while hovering; ignore.
->>>>>>> origin/main
     }
   }
   hoveredLinkRange = null

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -259,6 +259,7 @@ function getCaretTop(): number | null {
 }
 
 let hoveredLinkRange: { from: number; to: number } | null = null
+let selectionBeforeHover: { from: number; to: number } | null = null
 
 function toElement(target: EventTarget | null): Element | null {
   if (target instanceof Element) return target
@@ -280,6 +281,12 @@ function setHoverLinkSelection(target: EventTarget | null): boolean {
   if (!range) return false
   if (hoveredLinkRange && hoveredLinkRange.from === range.from && hoveredLinkRange.to === range.to) return true
 
+  // Save original cursor position on first hover entry so we can restore it on leave.
+  if (!hoveredLinkRange) {
+    const sel = editor.state.selection
+    selectionBeforeHover = { from: sel.from, to: sel.to }
+  }
+
   hoveredLinkRange = { from: range.from, to: range.to }
   editor.view.dispatch(
     editor.state.tr
@@ -290,7 +297,21 @@ function setHoverLinkSelection(target: EventTarget | null): boolean {
 }
 
 function clearHoverLinkSelection() {
+  const editor = tiptap.value
+  if (editor && selectionBeforeHover) {
+    const { from, to } = selectionBeforeHover
+    try {
+      editor.view.dispatch(
+        editor.state.tr
+          .setSelection(TextSelection.create(editor.state.doc, from, to))
+          .setMeta('addToHistory', false),
+      )
+    } catch {
+      // Position may be out of range if the document changed while hovering; ignore.
+    }
+  }
   hoveredLinkRange = null
+  selectionBeforeHover = null
 }
 
 function scrollToCaret() {

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -267,6 +267,10 @@ function toElement(target: EventTarget | null): Element | null {
   return null
 }
 
+function isLinkBubbleTarget(element: Element | null): boolean {
+  return !!element?.closest('.link-bubble')
+}
+
 function setHoverLinkSelection(target: EventTarget | null): boolean {
   const editor = tiptap.value
   const element = toElement(target)
@@ -300,14 +304,15 @@ function clearHoverLinkSelection() {
   const editor = tiptap.value
   if (editor && selectionBeforeHover) {
     const { from, to } = selectionBeforeHover
-    try {
+    const maxPos = editor.state.doc.content.size
+    const safeFrom = Math.max(0, Math.min(from, maxPos))
+    const safeTo = Math.max(0, Math.min(to, maxPos))
+    if (safeFrom <= safeTo) {
       editor.view.dispatch(
         editor.state.tr
-          .setSelection(TextSelection.create(editor.state.doc, from, to))
+          .setSelection(TextSelection.create(editor.state.doc, safeFrom, safeTo))
           .setMeta('addToHistory', false),
       )
-    } catch {
-      // Position may be out of range if the document changed while hovering; ignore.
     }
   }
   hoveredLinkRange = null
@@ -434,12 +439,16 @@ const tiptap = useEditor({
     },
     handleDOMEvents: {
       mouseover(_view, event) {
-        setHoverLinkSelection(event.target)
+        const element = toElement(event.target)
+        if (isLinkBubbleTarget(element)) return false
+        if (!setHoverLinkSelection(event.target)) {
+          clearHoverLinkSelection()
+        }
         return false
       },
       mouseout(_view, event) {
         const relatedElement = toElement(event.relatedTarget)
-        if (!relatedElement || !relatedElement.closest('.ProseMirror a')) {
+        if (!relatedElement || (!relatedElement.closest('.ProseMirror a') && !isLinkBubbleTarget(relatedElement))) {
           clearHoverLinkSelection()
         }
         return false


### PR DESCRIPTION
## Why

After the previous link rendering fix, hovering a link could select the link mark, but moving from the link to the tooltip would clear hover state too early. That prevented reliably using the tooltip actions to edit an existing URL.

There was also no direct UI for adding a link to already selected text unless the user used markdown syntax or paste behavior.

## What changed

- Updated link hover handling in `HomeView.vue` so hover selection is preserved when moving from a link into the link tooltip, then cleared when leaving both link and tooltip targets.
- Kept hover selection cleanup deterministic by clamping restored positions instead of swallowing selection restore errors.
- Expanded `LinkBubbleMenu` visibility logic to show for non-empty text selections, not only active links.
- Added an **Add link** action for selected text that opens the URL input and applies `setLink` to the selection.
- Reused the same edit input for both existing-link edit and new-link creation workflows.

## Result

Users can now:
1. Hover an existing link and reliably interact with the tooltip to edit the URL.
2. Select any word/phrase and add a new link directly from the tooltip menu.